### PR TITLE
Clear invalid characters from bytes

### DIFF
--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -1,12 +1,16 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/tatsuworks/gateway/discord"
 )
 
 func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (int64, error) {
+	// clear nulls
+	e.D = bytes.ToValidUTF8(e.D, nil)
+
 	switch e.T {
 	case "PRESENCE_UPDATE":
 		// return 0, c.PresenceUpdate(e.D)


### PR DESCRIPTION
Discord occasionally sends the event payloads which contains invalid characters such as null characters \\u0000— .
This cleans up the event and clears the invalid characters