### PR TITLE
Resume Gateway URL

### DIFF
--- a/discord/discordjson/websocket.go
+++ b/discord/discordjson/websocket.go
@@ -12,7 +12,8 @@ func (_ decoder) DecodeHello(buf []byte) (hbInterval int, trace string, _ error)
 	return hbInterval, "", nil
 }
 
-func (_ decoder) DecodeReady(buf []byte) (guilds map[int64][]byte, version int, sessionID string, _ error) {
+func (_ decoder) DecodeReady(buf []byte) (guilds map[int64][]byte, version int, sessionID string,
+	resumeGatewayURL string, _ error) {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -22,13 +23,14 @@ func (_ decoder) DecodeReady(buf []byte) (guilds map[int64][]byte, version int, 
 
 	version = jsoniter.Get(buf, "v").ToInt()
 	sessionID = jsoniter.Get(buf, "session_id").ToString()
+	resumeGatewayURL = jsoniter.Get(buf, "resume_gateway_url").ToString()
 
 	var _guilds []jsoniter.RawMessage
 	jsoniter.Get(buf, "guilds").ToVal(&_guilds)
 	guilds, err := rawsToMapBySnowflake(_guilds, "id")
 	if err != nil {
-		return nil, 0, "", err
+		return nil, 0, "", "", err
 	}
 
-	return guilds, version, sessionID, nil
+	return guilds, version, sessionID, resumeGatewayURL, nil
 }

--- a/discord/encoding.go
+++ b/discord/encoding.go
@@ -4,7 +4,7 @@ type Encoding interface {
 	Name() string
 
 	DecodeHello(buf []byte) (int, string, error)
-	DecodeReady(buf []byte) (guilds map[int64][]byte, version int, sessionID string, _ error)
+	DecodeReady(buf []byte) (guilds map[int64][]byte, version int, sessionID string, resumeGatewayURL string, _ error)
 
 	DecodeT(buf []byte) (*Event, error)
 

--- a/internal/gatewayws/persistence.go
+++ b/internal/gatewayws/persistence.go
@@ -42,6 +42,22 @@ func (s *Session) loadSessID() {
 	}
 }
 
+func (s *Session) persistResumeURL() {
+	err := s.stateDB.SetResumeGatewayURL(context.Background(), s.shardID, s.name, s.resumeURL)
+	if err != nil {
+		s.log.Error(s.ctx, "save resume gateway url", slog.Error(err))
+	}
+}
+
+func (s *Session) loadResumeURL() {
+	url, err := s.stateDB.GetResumeGatewayURL(context.Background(), s.shardID, s.name)
+	if err != nil {
+		s.log.Error(s.ctx, "load resume gateway url", slog.Error(err))
+		return
+	}
+	s.resumeURL = url
+}
+
 func (s *Session) persistStatus() {
 	err := s.stateDB.SetStatus(context.Background(), s.shardID, s.name, s.curState)
 	if err != nil {

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -42,10 +42,11 @@ type Session struct {
 	shardID    int
 	shardCount int
 
-	authed bool
-	seq    int64
-	sessID string
-	last   int64
+	authed    bool
+	seq       int64
+	sessID    string
+	resumeURL string
+	last      int64
 
 	wsConn *websocket.Conn
 	zr     io.ReadCloser
@@ -83,10 +84,12 @@ type Session struct {
 func (s *Session) Status() string {
 	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, s.curState, s.lastAck.Format(time.RFC3339))
 }
+
 func (s *Session) LongLastAck(threshold time.Duration) bool {
 	cutoff := time.Now().Add(-threshold)
 	return s.lastAck.Before(cutoff) && s.ready.Before(cutoff)
 }
+
 func (s *Session) cleanupBuffer() {
 	if s.buf != nil {
 		if s.buf.Cap() < (1 << 24) {
@@ -98,7 +101,11 @@ func (s *Session) cleanupBuffer() {
 	}
 	s.buf = nil
 }
+
 func (s *Session) GatewayURL() string {
+	if s.resumeURL != "" && s.sessID != "" {
+		return s.resumeURL
+	}
 	return "wss://gateway.discord.gg/?v=10&encoding=" + s.enc.Name() + "&compress=zlib-stream"
 }
 
@@ -145,6 +152,8 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 
 	sess.loadSessID()
 	sess.loadSeq()
+	sess.loadResumeURL()
+
 	return sess, nil
 }
 
@@ -330,6 +339,8 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 		s.persistSessID()
 		s.seq = 0
 		s.persistSeq()
+		s.resumeURL = ""
+		s.persistResumeURL()
 		s.wch = make(chan *Op, 2000)
 
 		if s.identifyMu.IsOwner().Result == etcdserverpb.Compare_EQUAL {
@@ -350,7 +361,7 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 	switch ev.T {
 	case "READY":
 		s.guilds = map[int64]struct{}{}
-		guilds, _, sess, err := s.enc.DecodeReady(ev.D)
+		guilds, _, sess, resumeURL, err := s.enc.DecodeReady(ev.D)
 		if err != nil {
 			return true, xerrors.Errorf("decode ready: %w", err)
 		}
@@ -360,8 +371,11 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 		}
 
 		s.sessID = sess
-		s.log.Info(s.ctx, "ready", slog.F("sess", sess), slog.F("guild_count", len(s.guilds)))
+		s.resumeURL = resumeURL
+		s.log.Info(s.ctx, "ready", slog.F("sess", sess), slog.F("resume_gateway_url", resumeURL),
+			slog.F("guild_count", len(s.guilds)))
 		s.persistSessID()
+		s.persistResumeURL()
 		s.authed = true
 		s.ready = time.Now()
 
@@ -428,8 +442,10 @@ func (s *Session) readAndDecodeEvent() (*discord.Event, error) {
 			if werr.Code == 4006 {
 				s.seq = 0
 				s.sessID = ""
+				s.resumeURL = ""
 				s.persistSeq()
 				s.persistSessID()
+				s.persistResumeURL()
 			}
 		}
 		return nil, xerrors.Errorf("read message: %w", err)

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -103,10 +103,13 @@ func (s *Session) cleanupBuffer() {
 }
 
 func (s *Session) GatewayURL() string {
+	wsOpts := "?v=10&encoding=" + s.enc.Name() + "&compress=zlib-stream"
+
 	if s.resumeURL != "" && s.sessID != "" {
-		return s.resumeURL
+		return s.resumeURL + wsOpts
 	}
-	return "wss://gateway.discord.gg/?v=10&encoding=" + s.enc.Name() + "&compress=zlib-stream"
+
+	return "wss://gateway.discord.gg/" + wsOpts
 }
 
 type SessionConfig struct {

--- a/internal/state/db/statefdb/shards.go
+++ b/internal/state/db/statefdb/shards.go
@@ -20,3 +20,9 @@ func (db *DB) GetSessionID(ctx context.Context, shard int, name string) (string,
 func (db *DB) SetStatus(ctx context.Context, shard int, name, sess string) error {
 	panic("unimplemented")
 }
+func (db *DB) SetResumeGatewayURL(ctx context.Context, shard int, name string, resumeURL string) error {
+	panic("unimplemented")
+}
+func (db *DB) GetResumeGatewayURL(ctx context.Context, shard int, name string) (string, error) {
+	panic("unimplemented")
+}

--- a/internal/state/db/statepsql/init.sql
+++ b/internal/state/db/statepsql/init.sql
@@ -112,16 +112,15 @@ CREATE INDEX CONCURRENTLY
 IF NOT EXISTS emojis_guild_id ON emojis
 ("guild_id");
 
-CREATE UNLOGGED TABLE
-IF NOT EXISTS shards
+CREATE UNLOGGED TABLE IF NOT EXISTS shards
 (
 	"id" int NOT NULL,
 	"name" text NOT NULL,
 	"seq" int8 NOT NULL,
 	"sess" text NOT NULL,
 	"status" text NOT NULL DEFAULT '',
-	PRIMARY KEY
-("id", "name")
+    "resume_url" text NOT NULL DEFAULT '',
+	PRIMARY KEY ("id", "name")
 );
 
 CREATE TABLE "public"."guilds_persistent"

--- a/internal/state/db/statepsql/shards.go
+++ b/internal/state/db/statepsql/shards.go
@@ -115,16 +115,16 @@ func (db *db) SetStatus(ctx context.Context, shard int, name, status string) err
 
 func (db *db) SetResumeGatewayURL(ctx context.Context, shard int, name string, resumeURL string) error {
 	const q = `
-				INSERT INTO
-					shards (id, name, seq, sess, resume_url)
-				VALUES
-					($1, $2, 0, '', $3)
-				ON CONFLICT
-					(id, name)
-				DO UPDATE
-				SET
-					resume_url = $3
-			`
+		INSERT INTO
+			shards (id, name, seq, sess, resume_url)
+		VALUES
+			($1, $2, 0, '', $3)
+		ON CONFLICT
+			(id, name)
+		DO UPDATE
+		SET
+			resume_url = $3
+	`
 
 	_, err := db.sql.ExecContext(ctx, q, shard, name, resumeURL)
 	if err != nil {
@@ -136,14 +136,14 @@ func (db *db) SetResumeGatewayURL(ctx context.Context, shard int, name string, r
 
 func (db *db) GetResumeGatewayURL(ctx context.Context, shard int, name string) (string, error) {
 	const q = `
-				SELECT
-					resume_url
-				FROM
-					shards
-				WHERE
-					id = $1 AND
-					name = $2
-				`
+		SELECT
+			resume_url
+		FROM
+			shards
+		WHERE
+			id = $1 AND
+			name = $2
+	`
 
 	var resumeURL string
 	err := db.sql.GetContext(ctx, &resumeURL, q, shard, name)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -15,6 +15,8 @@ type DB interface {
 	SetSessionID(ctx context.Context, shard int, name string, sess string) error
 	GetSessionID(ctx context.Context, shard int, name string) (string, error)
 	SetStatus(ctx context.Context, shard int, name string, status string) error
+	SetResumeGatewayURL(ctx context.Context, shard int, name string, resumeURL string) error
+	GetResumeGatewayURL(ctx context.Context, shard int, name string) (string, error)
 
 	SetGuild(ctx context.Context, id int64, raw []byte) (bool, error)
 	GetGuild(ctx context.Context, id int64) ([]byte, error)


### PR DESCRIPTION
Add support for `resume_gateway_url` for resuming gateway sessions.

This was added by Discord in August 2022. They say as of 12 Sept 2022, apps not using this will experience faster disconnections than normal 🤨 

https://discord.com/developers/docs/change-log#sessionspecific-gateway-resume-urls

DB will need to be updated with an additional field for the shards table `resume_url`.