### PR TITLE
Change game access check to include staff, on top of beta testers

### DIFF
--- a/internal/state/api/api.go
+++ b/internal/state/api/api.go
@@ -89,7 +89,7 @@ func (s *Server) Init() {
 	s.router.DELETE(path.Join(base, "guilds", ":guild", "channels","wipe"), wrapHandler(s.log, s.deleteGuildChannels))
 
 	s.router.GET(path.Join(base, "users"), wrapHandler(s.log, s.getUsers))
-	s.router.GET(path.Join(base, "user_in_guilds_has_roles"), wrapHandler(s.log,s.getUserInGuildsHasRoles))
+	s.router.GET(path.Join(base, "user_in_guilds_has_roles"), wrapHandler(s.log,s.existUserInGuildsHasRoles))
 }
 
 func (s *Server) Start(addr string) error {

--- a/internal/state/api/api.go
+++ b/internal/state/api/api.go
@@ -89,7 +89,7 @@ func (s *Server) Init() {
 	s.router.DELETE(path.Join(base, "guilds", ":guild", "channels","wipe"), wrapHandler(s.log, s.deleteGuildChannels))
 
 	s.router.GET(path.Join(base, "users"), wrapHandler(s.log, s.getUsers))
-	s.router.GET(path.Join(base,"guilds",":guild","roles",":role","users",":user"),wrapHandler(s.log,s.getUserInGuildHasRole))
+	s.router.GET(path.Join(base, "user_in_guilds_has_roles"), wrapHandler(s.log,s.getUserInGuildsHasRoles))
 }
 
 func (s *Server) Start(addr string) error {

--- a/internal/state/api/members.go
+++ b/internal/state/api/members.go
@@ -258,7 +258,7 @@ func (s *Server) setGuildMembers(w http.ResponseWriter, r *http.Request, p httpr
 	return nil
 }
 
-func (s *Server) getUserInGuildsHasRoles(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
+func (s *Server) existUserInGuildsHasRoles(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 	userID := r.URL.Query().Get("user_id")
 	roleIDs := r.URL.Query().Get("role_ids")
 	guildIDs := r.URL.Query().Get("server_ids")
@@ -271,7 +271,6 @@ func (s *Server) getUserInGuildsHasRoles(w http.ResponseWriter, r *http.Request,
 	guildIDsSliced := strings.Split(guildIDs, ",")
 
 	var convertedUserID int64
-	var convertedRoleIDs []int64
 	var convertedGuildIDs []int64
 
 	value, err := strconv.ParseInt(userID,10,64);
@@ -279,14 +278,6 @@ func (s *Server) getUserInGuildsHasRoles(w http.ResponseWriter, r *http.Request,
 		return xerrors.Errorf("parse int for userID: %w", err)
 	}
 	convertedUserID = value
-
-	for _, roleId := range roleIDsSliced {
-		value, err = strconv.ParseInt(roleId,10,64);
-		if err != nil {
-			return xerrors.Errorf("parse int for roleIdsSliced array: %w", err)
-		}
-		convertedRoleIDs = append(convertedRoleIDs,value)
-	}
 
 	for _, guildId := range guildIDsSliced {
 		value, err = strconv.ParseInt(guildId,10,64);
@@ -296,7 +287,7 @@ func (s *Server) getUserInGuildsHasRoles(w http.ResponseWriter, r *http.Request,
 		convertedGuildIDs = append(convertedGuildIDs,value)
 	}
 
-	exists, err := s.db.GetUserInGuildsHasRoles(r.Context(),convertedGuildIDs,convertedRoleIDs,convertedUserID)
+	exists, err := s.db.ExistUserInGuildsHasRoles(r.Context(),convertedGuildIDs,roleIDsSliced,convertedUserID)
 	if err != nil {
 		return xerrors.Errorf("check user guilds and roles existence: %w", err)
 	}

--- a/internal/state/db/statefdb/member.go
+++ b/internal/state/db/statefdb/member.go
@@ -106,6 +106,6 @@ func (db *DB) DeleteGuildRolesById(ctx context.Context, guildID int64, roleIDs [
 	panic("unimplemented")
 }
 
-func (db *DB) GetUserInGuildHasRole(ctx context.Context, guildID int64, roleID int64, userID int64) (bool, error) {
+func (db *DB) GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []int64, userID int64) (bool, error) {
 	panic("unimplemented")
 }

--- a/internal/state/db/statefdb/member.go
+++ b/internal/state/db/statefdb/member.go
@@ -106,6 +106,6 @@ func (db *DB) DeleteGuildRolesById(ctx context.Context, guildID int64, roleIDs [
 	panic("unimplemented")
 }
 
-func (db *DB) GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []int64, userID int64) (bool, error) {
+func (db *DB) ExistUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []string, userID int64) (bool, error) {
 	panic("unimplemented")
 }

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -336,7 +336,7 @@ func (db *db) GetUserInGuildHasRole(ctx context.Context, guildID int64, roleID i
 	return exists, nil
 }
 
-func (db *db) GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []int64, userID int64) (bool, error) {
+func (db *db) ExistUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []string, userID int64) (bool, error) {
 	const q = `
 	SELECT EXISTS(
 		SELECT
@@ -348,7 +348,7 @@ func (db *db) GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, rol
 			EXISTS (
 				SELECT 1
 				FROM jsonb_array_elements_text(data->'roles') AS role
-				WHERE role::text = ANY ($2::text[])
+				WHERE role = ANY ($2)
 			)
 	)
 	`

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -69,7 +69,7 @@ type DB interface {
 	DeleteGuildRoles(ctx context.Context, guild int64) error
 	DeleteGuildRole(ctx context.Context, guild, role int64) error
 	DeleteGuildRolesById(ctx context.Context, guildID int64, roleIDs []int64) error
-	GetUserInGuildHasRole(ctx context.Context, guildID int64, roleID int64, userID int64) (bool, error)
+	GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []int64, userID int64) (bool, error)
 
 	SetGuildEmojis(ctx context.Context, guild int64, raws map[int64][]byte) error
 	SetGuildEmoji(ctx context.Context, guild, emoji int64, raw []byte) error

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -69,7 +69,7 @@ type DB interface {
 	DeleteGuildRoles(ctx context.Context, guild int64) error
 	DeleteGuildRole(ctx context.Context, guild, role int64) error
 	DeleteGuildRolesById(ctx context.Context, guildID int64, roleIDs []int64) error
-	GetUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []int64, userID int64) (bool, error)
+	ExistUserInGuildsHasRoles(ctx context.Context, guildIDs []int64, roleIDs []string, userID int64) (bool, error)
 
 	SetGuildEmojis(ctx context.Context, guild int64, raws map[int64][]byte) error
 	SetGuildEmoji(ctx context.Context, guild, emoji int64, raw []byte) error


### PR DESCRIPTION
Previously the laporte graphql query check if user is in discord server meant for playtesters and has the "testers" role to be able to access the game. I extended this to include "admin", also "staff" from the Tatsu Works server. Which means I changed the endpoint to accept array for input (guild ids, role ids)