### PR TITLE
Remove single-redis configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,40 @@ Events are pushed to [redis](https://redis.io) using `RPUSH`. The content is the
 ## Common Dependencies
 
 1. Ensure you have Go 1.13 or higher.
-1. Install [foundationdb](https://www.foundationdb.org/download/) (both the server and clients package).
-1. Install [redis](https://redis.io).
+2. Install [foundationdb](https://www.foundationdb.org/download/) (both the server and clients package).
+3. Install [redis](https://redis.io).
 
 ## Setting up the Gateway
 
 1. Add a variable in `cmd/gateway/main.go` named `Token` that contains your token.
-1. Enable modules `export GO111MODULE=on`
-1. Run `go build` in `cmd/gateway`
-1. To run, do `./gateway` in `cmd/gateway`
-1. To only push certain event types to the event queue, set the `WHITELIST_EVENTS` environment variable e.g `WHITELIST_EVENTS=MESSAGE_CREATE,MESSAGE_REACTION_ADD`
+2. Enable modules `export GO111MODULE=on`
+3. Run `go build` in `cmd/gateway`
+4. To run, do `./gateway` in `cmd/gateway`
+
+### Redis Configuration
+
+The gateway requires the `MULTI_REDIS` environment variable to be set. This allows you to configure one or more Redis instances with optional per-instance event filtering.
+
+**Format:** `{"redis_address": ["EVENT_TYPE1", "EVENT_TYPE2"], ...}`
+
+**Examples:**
+
+Single Redis instance, no event filtering (all events sent):
+```bash
+export MULTI_REDIS='{"localhost:6379":[]}'
+```
+
+Single Redis instance with event filtering:
+```bash
+export MULTI_REDIS='{"localhost:6379":["MESSAGE_CREATE","MESSAGE_UPDATE","MESSAGE_DELETE"]}'
+```
+
+Multiple Redis instances with different event filters:
+```bash
+export MULTI_REDIS='{"redis1.example.com:6379":["MESSAGE_CREATE","MESSAGE_UPDATE"],"redis2.example.com:6379":["GUILD_CREATE","GUILD_UPDATE"]}'
+```
 
 ## Setting up the State
 
 1. Run `go build` in `cmd/state`
-1. To run, do `./state` in `cmd/state`
+2. To run, do `./state` in `cmd/state`

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -26,17 +25,16 @@ import (
 )
 
 var (
-	name      string
-	token     string
-	redisHost string
-	etcdHost  string
-	pprof     string
-	prod      string
-	psql      bool
-	psqlAddr  string
-	addr      string
-	intents   string
-	podId     string
+	name     string
+	token    string
+	etcdHost string
+	pprof    string
+	prod     string
+	psql     bool
+	psqlAddr string
+	addr     string
+	intents  string
+	podId    string
 
 	shards, start, stop int
 )
@@ -44,7 +42,6 @@ var (
 func init() {
 	flag.StringVar(&name, "name", "gateway", "name of gateway")
 	flag.StringVar(&token, "token", "", "token for the bot")
-	flag.StringVar(&redisHost, "redis", "localhost:6379", "localhost:6379")
 	flag.StringVar(&etcdHost, "etcd", "http://localhost:2379,http://localhost:4001", "")
 	flag.StringVar(&pprof, "pprof", "localhost:6060", "Address for pprof to listen on")
 	flag.StringVar(&prod, "prod", "", "Enable production logging")
@@ -130,37 +127,23 @@ func main() {
 		logger.Fatal(ctx, "listen", slog.Error(err))
 	}
 
-	events := os.Getenv("WHITELIST_EVENTS")
-	var whitelistedEventLookup map[string]struct{}
-	if events != "" {
-		whitelistedEvents := strings.Split(events, ",")
-		whitelistedEventLookup = make(map[string]struct{}, len(whitelistedEvents))
-		var empty struct{}
-		for _, evt := range whitelistedEvents {
-			whitelistedEventLookup[evt] = empty
-		}
-	}
-
 	wg := &sync.WaitGroup{}
 	m := manager.New(ctx, &manager.Config{
-		Name:              name,
-		Logger:            logger,
-		Wg:                wg,
-		DB:                statedb,
-		Token:             token,
-		Shards:            shards,
-		Intents:           ints,
-		RedisAddr:         redisHost,
-		EtcdAddr:          etcdHost,
-		PodID:             podId,
-		WhitelistedEvents: whitelistedEventLookup,
+		Name:     name,
+		Logger:   logger,
+		Wg:       wg,
+		DB:       statedb,
+		Token:    token,
+		Shards:   shards,
+		Intents:  ints,
+		EtcdAddr: etcdHost,
+		PodID:    podId,
 	})
 
 	logger.Info(ctx, "starting manager",
 		slog.F("shards", shards),
 		slog.F("start", start),
 		slog.F("stop", stop),
-		slog.F("redis_host", redisHost),
 		slog.F("etcd_host", etcdHost),
 	)
 

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -283,7 +283,7 @@ func (s *Session) Open(ctx context.Context, token string) error {
 	defer s.persistSeq()
 
 	for {
-		s.log.Debug(s.ctx, "received event", slog.F("last_ack", s.lastAck.Format(time.RFC3339)), slog.F("last_hb", s.lastHB.Format(time.RFC3339)), slog.F("seq", atomic.LoadInt64(&s.seq)))
+		s.log.Debug(s.ctx, "received event", slog.F("last_ack", s.lastAck), slog.F("last_hb", s.lastHB), slog.F("seq", atomic.LoadInt64(&s.seq)))
 
 		ev, err := s.readAndDecodeEvent()
 		if err != nil {
@@ -293,29 +293,28 @@ func (s *Session) Open(ctx context.Context, token string) error {
 		if ev.S != 0 {
 			atomic.StoreInt64(&s.seq, ev.S)
 		}
-
-		s.log.Debug(s.ctx, "event info", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
+		s.log.Debug(s.ctx, "decoded event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 
 		s.curState = "handle internal event " + ev.T
+		s.log.Debug(s.ctx, "handling internal event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		var handled bool
 		if handled, err = s.handleInternalEvent(ev); handled {
 			if err != nil {
 				break
 			}
-
 			continue
 		}
 
 		s.curState = "handle state event " + ev.T
+		s.log.Debug(s.ctx, "handling state event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		evtPayload, err := s.state.HandleEvent(ctx, ev)
 		if err != nil {
 			s.log.Error(s.ctx, "handle state event", slog.Error(err))
 			continue
 		}
 
-		s.log.Debug(s.ctx, "handled event", slog.F("type", ev.T))
-
 		s.curState = "push event to redis"
+		s.log.Debug(s.ctx, "pushing event to redis", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		s.pushEventToRedis(ev)
 
 		// request for guild member info only on GUILD_CREATE events and if the intent is set
@@ -346,11 +345,10 @@ func (s *Session) pushEventToRedis(ev *discord.Event) {
 			}
 		}
 
+		s.log.Debug(s.ctx, "pushing event to redis", slog.F("event type", ev.T), slog.F("redis addr", addr))
 		if err := rc.RPush(s.ctx, "gateway:events:"+ev.T, ev.D).Err(); err != nil {
-			s.log.Error(s.ctx, "push event to redis", slog.Error(err))
+			s.log.Error(s.ctx, "push event to redis", slog.Error(err), slog.F("event type", ev.T), slog.F("redis addr", addr))
 		}
-
-		s.log.Debug(s.ctx, "pushed event to redis", slog.F("event type", ev.T), slog.F("redis addr", addr))
 	}
 
 	for _, rc := range s.rc {

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -82,8 +82,7 @@ type Session struct {
 
 	state   *handler.Client
 	stateDB state.DB
-	rc      *redis.Client
-	multirc []*redis.Client
+	rc      []*redis.Client
 
 	whitelistedEvents map[string]map[string]struct{}
 
@@ -126,8 +125,7 @@ type SessionConfig struct {
 	Logger            slog.Logger
 	DB                state.DB
 	WorkGroup         *sync.WaitGroup
-	Redis             *redis.Client
-	MultiRedis        []*redis.Client
+	Redis             []*redis.Client
 	Etcd              *clientv3.Client
 	Token             string
 	Intents           Intents
@@ -159,7 +157,6 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 		stateDB:           cfg.DB,
 		enc:               cfg.DB.Encoding(),
 		rc:                cfg.Redis,
-		multirc:           cfg.MultiRedis,
 		bufferPool:        cfg.BufferPool,
 		whitelistedEvents: cfg.WhitelistedEvents,
 	}
@@ -286,6 +283,8 @@ func (s *Session) Open(ctx context.Context, token string) error {
 	defer s.persistSeq()
 
 	for {
+		s.log.Debug(s.ctx, "received event", slog.F("last_ack", s.lastAck.Format(time.RFC3339)), slog.F("last_hb", s.lastHB.Format(time.RFC3339)), slog.F("seq", atomic.LoadInt64(&s.seq)))
+
 		ev, err := s.readAndDecodeEvent()
 		if err != nil {
 			s.log.Error(ctx, "read and decode event", slog.Error(err))
@@ -294,6 +293,8 @@ func (s *Session) Open(ctx context.Context, token string) error {
 		if ev.S != 0 {
 			atomic.StoreInt64(&s.seq, ev.S)
 		}
+
+		s.log.Debug(s.ctx, "event info", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 
 		s.curState = "handle internal event " + ev.T
 		var handled bool
@@ -311,6 +312,8 @@ func (s *Session) Open(ctx context.Context, token string) error {
 			s.log.Error(s.ctx, "handle state event", slog.Error(err))
 			continue
 		}
+
+		s.log.Debug(s.ctx, "handled event", slog.F("type", ev.T))
 
 		s.curState = "push event to redis"
 		s.pushEventToRedis(ev)
@@ -335,9 +338,10 @@ func (s *Session) pushEventToRedis(ev *discord.Event) {
 		return
 	}
 	push := func(addr string, rc *redis.Client) {
-		if s.whitelistedEvents != nil {
-			if _, ok := s.whitelistedEvents[addr][ev.T]; !ok {
-				s.log.Debug(s.ctx, "not whitelisted", slog.F("event type", ev.T))
+		if whitelist, exists := s.whitelistedEvents[addr]; exists {
+			s.log.Debug(s.ctx, "checking whitelist", slog.F("event type", ev.T), slog.F("redis addr", addr))
+			if _, ok := whitelist[ev.T]; !ok {
+				s.log.Debug(s.ctx, "not whitelisted", slog.F("event type", ev.T), slog.F("redis addr", addr))
 				return
 			}
 		}
@@ -345,14 +349,12 @@ func (s *Session) pushEventToRedis(ev *discord.Event) {
 		if err := rc.RPush(s.ctx, "gateway:events:"+ev.T, ev.D).Err(); err != nil {
 			s.log.Error(s.ctx, "push event to redis", slog.Error(err))
 		}
+
+		s.log.Debug(s.ctx, "pushed event to redis", slog.F("event type", ev.T), slog.F("redis addr", addr))
 	}
 
-	if s.multirc != nil {
-		for _, rc := range s.multirc {
-			push(rc.Options().Addr, rc)
-		}
-	} else {
-		push(s.rc.Options().Addr, s.rc)
+	for _, rc := range s.rc {
+		push(rc.Options().Addr, rc)
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -30,9 +30,8 @@ type Manager struct {
 	shardMu sync.Mutex
 	shards  map[int]*gatewayws.Session
 
-	rdb        *redis.Client
-	rdbClients []*redis.Client
-	etcd       *clientv3.Client
+	rdb  []*redis.Client
+	etcd *clientv3.Client
 
 	bufferPool *sync.Pool
 
@@ -40,75 +39,74 @@ type Manager struct {
 }
 
 type Config struct {
-	Name              string
-	Logger            slog.Logger
-	DB                state.DB
-	Wg                *sync.WaitGroup
-	Token             string
-	Shards            int
-	Intents           gatewayws.Intents
-	RedisAddr         string
-	EtcdAddr          string
-	PodID             string
-	WhitelistedEvents map[string]struct{}
+	Name     string
+	Logger   slog.Logger
+	DB       state.DB
+	Wg       *sync.WaitGroup
+	Token    string
+	Shards   int
+	Intents  gatewayws.Intents
+	EtcdAddr string
+	PodID    string
 }
 
 func New(ctx context.Context, cfg *Config) *Manager {
 	multiRedisEnv := os.Getenv("MULTI_REDIS")
-	var rc *redis.Client
+	if multiRedisEnv == "" {
+		cfg.Logger.Fatal(ctx, "MULTI_REDIS environment variable is required")
+	}
+
 	var rdbClients []*redis.Client
-	// maps redis address to map of whitelisted events
 	var redisWhitelistedEvents = make(map[string]map[string]struct{})
 	var err error
 
-	if multiRedisEnv != "" {
-		// Parse as map[address][]events
-		var multiRedisConfig map[string][]string
-		err = json.Unmarshal([]byte(multiRedisEnv), &multiRedisConfig)
-		if err != nil {
-			cfg.Logger.Fatal(ctx, "invalid MULTI_REDIS format", slog.Error(err))
-		}
+	var multiRedisConfig map[string][]string
+	err = json.Unmarshal([]byte(multiRedisEnv), &multiRedisConfig)
+	if err != nil {
+		cfg.Logger.Fatal(ctx, "invalid MULTI_REDIS format", slog.Error(err))
+	}
 
-		for address, events := range multiRedisConfig {
-			var mrc *redis.Client
-			mrc, err = createRedisClient(ctx, address, cfg.Name, cfg.PodID)
-			if err != nil {
-				// It is not fatal if one multiRedis client did not connect.
-				cfg.Logger.Warn(ctx, "createRedisClient",
+	for address, events := range multiRedisConfig {
+		var mrc *redis.Client
+		mrc, err = createRedisClient(ctx, address, cfg.Name, cfg.PodID)
+		if err != nil {
+			if os.Getenv("PROD") == "true" {
+				cfg.Logger.Fatal(ctx, "createRedisClient",
 					slog.F("address", address),
 					slog.Error(err))
-				continue
 			}
-			rdbClients = append(rdbClients, mrc)
 
-			// Convert string slice to map[string]struct{}
+			// Not all multiRedis clients need to connect in development.
+			cfg.Logger.Warn(ctx, "createRedisClient",
+				slog.F("address", address),
+				slog.Error(err))
+			continue
+		}
+		rdbClients = append(rdbClients, mrc)
+
+		if len(events) > 0 {
 			whitelistForClient := make(map[string]struct{})
-
-			// If specific events are configured for this Redis instance
-			if len(events) > 0 {
-				for _, event := range events {
-					whitelistForClient[event] = struct{}{}
-				}
-			} else {
-				// If no specific events configured, use all global whitelisted events
-				whitelistForClient = cfg.WhitelistedEvents
+			for _, event := range events {
+				whitelistForClient[event] = struct{}{}
 			}
-
-			// Store the whitelist keyed by Redis address
 			redisWhitelistedEvents[mrc.Options().Addr] = whitelistForClient
 		}
-
-		// No multi redis clients were connected, or all failed to connect.
-		if len(rdbClients) == 0 {
-			cfg.Logger.Fatal(ctx, "multiRedisEnv is set, but all redis clients failed to connect.")
-		}
-	} else {
-		rc, err = createRedisClient(ctx, cfg.RedisAddr, cfg.Name, cfg.PodID)
-		if err != nil {
-			cfg.Logger.Fatal(ctx, "createRedisClient", slog.Error(err))
-		}
-		redisWhitelistedEvents[rc.Options().Addr] = cfg.WhitelistedEvents
 	}
+
+	// No multi redis clients were connected, or all failed to connect.
+	if len(rdbClients) == 0 {
+		cfg.Logger.Fatal(ctx, "all redis clients failed to connect")
+	}
+
+	// This collects the addresses of all CONNECTED redis clients.
+	addresses := make([]string, 0, len(rdbClients))
+	for _, c := range rdbClients {
+		if c == nil || c.Options() == nil {
+			continue
+		}
+		addresses = append(addresses, c.Options().Addr)
+	}
+	cfg.Logger.Info(ctx, "initialized redis clients", slog.F("count", len(rdbClients)), slog.F("addrs", strings.Join(addresses, ",")))
 
 	etcdc, err := clientv3.New(clientv3.Config{
 		Endpoints:   strings.Split(cfg.EtcdAddr, ","),
@@ -131,9 +129,8 @@ func New(ctx context.Context, cfg *Config) *Manager {
 
 		shards: map[int]*gatewayws.Session{},
 
-		rdb:        rc,
-		rdbClients: rdbClients,
-		etcd:       etcdc,
+		rdb:  rdbClients,
+		etcd: etcdc,
 
 		bufferPool: &sync.Pool{
 			New: func() interface{} {
@@ -168,14 +165,13 @@ func (m *Manager) startShard(shard int) {
 		DB:                m.db,
 		WorkGroup:         m.wg,
 		Redis:             m.rdb,
-		MultiRedis:        m.rdbClients,
 		Etcd:              m.etcd,
 		Token:             m.token,
 		Intents:           m.intents,
 		ShardID:           shard,
 		ShardCount:        m.shardCount,
 		BufferPool:        m.bufferPool,
-		WhitelistedEvents: m.whitelistedEvents, // Pass the per-redis whitelisted events
+		WhitelistedEvents: m.whitelistedEvents,
 	})
 	if err != nil {
 		m.log.Error(m.ctx, "make gateway session", slog.Error(err))


### PR DESCRIPTION
This removes single-redis configuration of Gateway to simplify maintenance. 

- `--redis` configuration option removed
- `WHITELIST_EVENTS` env removed, whitelisting done through `MULTI_REDIS` env instead.
- Adds some debugging logs to event loop
- Made multi-redis fatal if a client fails to connect in prod