### PR TITLE
Fix GetUser query to use snowflake ordering via PK index

### DIFF
--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -254,14 +254,15 @@ WHERE
 }
 
 func (db *db) GetUser(ctx context.Context, userID int64) ([]byte, error) {
+	// ORDER BY guild_id DESC exploits the composite PK index (guild_id, user_id):
+	// guild_id is a Discord snowflake, so higher == more recently joined guild,
+	// which carries the freshest user object. No extra index needed.
 	q := `
-SELECT
-	data->'user'
-FROM
-	members
-WHERE
-	user_id = $1
-ORDER BY last_updated desc nulls last limit 1
+SELECT data->'user'
+FROM members
+WHERE user_id = $1
+ORDER BY guild_id DESC
+LIMIT 1
 `
 
 	var usr RawJSON


### PR DESCRIPTION
guild_id is a Discord snowflake (monotonically increasing), so ORDER BY guild_id DESC on the composite PK (guild_id, user_id) returns the freshest user object without a separate last_updated index.

without this change it's loading all the rows for a particular user before sorting on last updated. (extremely slow for users in many servers like the tatsu bot)