### PR TITLE
Optimize SearchGuildMembers and GetUser queries with indexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Discord Gateway & State Cache service for Tatsu. Two components:
+- **Gateway** (`cmd/gateway/`) — Multiplexes many Discord WebSocket connections (720+ shards at peak, ~4 cores). Publishes events to Redis via RPUSH with ETF-encoded payloads.
+- **State Cache** (`cmd/state/`) — HTTP/2 REST API for querying cached Discord state (guilds, channels, members, roles, messages, threads).
+
+## Build & Run
+
+```bash
+# Gateway
+cd cmd/gateway && go build -o gateway . && ./gateway
+
+# State Cache
+cd cmd/state && go build -o state . && ./state
+```
+
+## Testing
+
+```bash
+go test ./...                              # All tests
+go test ./discord/discordjson/...          # JSON encoding tests
+go test ./internal/gatewayws/...           # WebSocket session tests
+go test -run TestFoo ./path/to/pkg         # Single test
+go test -bench . ./discord/discordjson    # Benchmarks
+```
+
+## Code Generation
+
+Protobuf generation for gRPC management API:
+```bash
+./gen.sh   # runs protoc with gogofaster plugin → gatewaypb/
+```
+
+## Architecture
+
+### Event Flow
+```
+Discord WS → gatewayws.Session → handler.Client → state.DB (store) → Manager → Redis RPUSH → consumers (BLPOP)
+```
+
+### Key Packages
+- `internal/gatewayws/` — WebSocket session lifecycle per shard (connect, read, write, heartbeat, identify)
+- `internal/manager/` — Multi-shard orchestration, Redis event routing, gRPC management server
+- `handler/` — Discord event processing (guild, channel, member, message, role, emoji, thread events)
+- `internal/state/` — `state.DB` interface (~93 methods) abstracting storage backends
+- `internal/state/db/statefdb/` — FoundationDB implementation (primary)
+- `internal/state/db/statepsql/` — PostgreSQL implementation (fallback)
+- `internal/state/api/` — REST API handlers for state queries (fasthttp + httprouter)
+- `discord/discordetf/` — Custom ETF (Erlang Term Format) encoder/decoder built from scratch
+- `discord/discordjson/` — JSON encoding alternative
+- `gatewaypb/` — Protobuf definitions for gRPC management API (Version, RequestGuildMembers, RestartShard, Stats)
+
+### Coordination
+- **etcd** — Distributed mutex for shard identify rate limiting
+- **Redis** — Event queue with per-instance event type filtering via `MULTI_REDIS` env var
+- **gRPC** — Management API for shard control
+
+### Key Interfaces
+- `discord.Encoding` — Abstraction over ETF vs JSON encoding
+- `state.DB` — Storage backend abstraction (FoundationDB or PostgreSQL)
+
+## Environment Variables
+
+- `MULTI_REDIS` — JSON map of Redis addresses to event type filters (required for gateway). Empty array = all events.
+- `TOKEN` — Discord bot token
+- `ETCD` — etcd endpoints (default: `http://localhost:2379,http://localhost:4001`)
+- `SHARDS` — Total shard count
+- `START`/`STOP` — Shard range (inclusive/exclusive)
+- `INTENTS` — Discord intent set: `default`, `all`, `fast`
+- `PSQL` — PostgreSQL address (fallback; otherwise uses FoundationDB)
+- `PROD` — Enables production logging (JSON/stackdriver vs human-readable)
+
+## Dependencies
+
+Requires FoundationDB client libraries (v6.2.27) installed on the system. Redis and etcd must be available at runtime.

--- a/internal/state/api/members.go
+++ b/internal/state/api/members.go
@@ -106,13 +106,26 @@ func (s *Server) searchGuildMembers(w http.ResponseWriter, r *http.Request, p ht
 	if err != nil {
 		return xerrors.Errorf("read guild param: %w", err)
 	}
+
+	const defaultLimit, maxLimit = 100, 1000
+	limit := defaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		limit, err = strconv.Atoi(raw)
+		if err != nil || limit < 1 {
+			return xerrors.Errorf("invalid limit: must be a positive integer")
+		}
+		if limit > maxLimit {
+			limit = maxLimit
+		}
+	}
+
 	var (
 		ctx   = r.Context()
 		query = r.URL.Query().Get("query")
 	)
 	var ms [][]byte
 	if query != "" && len(query) > 2 {
-		ms, err = s.db.SearchGuildMembers(ctx, g, query)
+		ms, err = s.db.SearchGuildMembers(ctx, g, query, limit)
 		if err != nil {
 			return xerrors.Errorf("search members: %w", err)
 		}

--- a/internal/state/api/roles.go
+++ b/internal/state/api/roles.go
@@ -59,6 +59,9 @@ func (s *Server) getGuildRoleSlice(w http.ResponseWriter, r *http.Request, p htt
 	)
 
 	for _, e := range rs {
+		if e == "" {
+			continue
+		}
 		rr, err := strconv.ParseInt(e, 10, 64)
 		if err != nil {
 			return xerrors.Errorf("parse role id: %w", err)

--- a/internal/state/db/statefdb/member.go
+++ b/internal/state/db/statefdb/member.go
@@ -78,7 +78,7 @@ func (db *DB) GetUsersDiscordIdAndUsername(ctx context.Context, userIDs []int64)
 	panic("unimplemented")
 }
 
-func (db *DB) SearchGuildMembers(ctx context.Context, guildID int64, query string) ([][]byte, error) {
+func (db *DB) SearchGuildMembers(ctx context.Context, guildID int64, query string, limit int) ([][]byte, error) {
 	panic("unimplemented")
 }
 

--- a/internal/state/db/statepsql/init.sql
+++ b/internal/state/db/statepsql/init.sql
@@ -72,6 +72,17 @@ IF NOT EXISTS members_guild_id ON members
 CREATE INDEX CONCURRENTLY
 IF NOT EXISTS members_user_id ON members
 ("user_id");
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX CONCURRENTLY
+IF NOT EXISTS members_search_trgm ON members
+USING GIN (
+	lower(
+		coalesce(data->'user'->>'global_name', '') || ' ' ||
+		coalesce(data->'user'->>'display_name', '') || ' ' ||
+		coalesce(data->'user'->>'username', '') || ' ' ||
+		coalesce(data->>'nick', '')
+	) gin_trgm_ops
+);
 
 CREATE UNLOGGED TABLE
 IF NOT EXISTS messages

--- a/internal/state/db/statepsql/init.sql
+++ b/internal/state/db/statepsql/init.sql
@@ -67,9 +67,6 @@ EXECUTE PROCEDURE update_last_updated_column
 
 -- SELECT create_distributed_table('members', 'guild_id');
 CREATE INDEX CONCURRENTLY
-IF NOT EXISTS members_guild_id ON members
-("guild_id");
-CREATE INDEX CONCURRENTLY
 IF NOT EXISTS members_user_id ON members
 ("user_id");
 CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -291,7 +291,7 @@ func (db *db) GetUsersDiscordIdAndUsername(ctx context.Context, userIDs []int64)
 	return usersAndData, nil
 }
 
-func (db *db) SearchGuildMembers(ctx context.Context, guildID int64, query string) ([][]byte, error) {
+func (db *db) SearchGuildMembers(ctx context.Context, guildID int64, query string, limit int) ([][]byte, error) {
 	// Fields are concatenated for GIN trigram matching via members_search_trgm index.
 	// Trade-off: may produce cross-field false positives (e.g. "foo b" matching
 	// global_name="foo" + username="bar"), which is acceptable for best-effort search.
@@ -308,10 +308,11 @@ WHERE
 		coalesce(data->'user'->>'username', '') || ' ' ||
 		coalesce(data->>'nick', '')
 	) LIKE $2
+LIMIT $3
 `
 
 	var ms []RawJSON
-	err := db.sql.SelectContext(ctx, &ms, q, guildID, "%"+strings.ToLower(query)+"%")
+	err := db.sql.SelectContext(ctx, &ms, q, guildID, "%"+strings.ToLower(query)+"%", limit)
 	if err != nil {
 		return nil, xerrors.Errorf("exec select: %w", err)
 	}

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -292,6 +292,9 @@ func (db *db) GetUsersDiscordIdAndUsername(ctx context.Context, userIDs []int64)
 }
 
 func (db *db) SearchGuildMembers(ctx context.Context, guildID int64, query string) ([][]byte, error) {
+	// Fields are concatenated for GIN trigram matching via members_search_trgm index.
+	// Trade-off: may produce cross-field false positives (e.g. "foo b" matching
+	// global_name="foo" + username="bar"), which is acceptable for best-effort search.
 	const q = `
 SELECT
 	data

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -254,14 +254,15 @@ WHERE
 }
 
 func (db *db) GetUser(ctx context.Context, userID int64) ([]byte, error) {
+	// ORDER BY guild_id DESC exploits the composite PK index (guild_id, user_id):
+	// guild_id is a Discord snowflake, so higher == more recently joined guild,
+	// which carries the freshest user object. No extra index needed.
 	q := `
-SELECT
-	data->'user'
-FROM
-	members
-WHERE
-	user_id = $1
-ORDER BY last_updated desc nulls last limit 1
+SELECT data->'user'
+FROM members
+WHERE user_id = $1
+ORDER BY guild_id DESC
+LIMIT 1
 `
 
 	var usr RawJSON

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -298,16 +298,17 @@ SELECT
 FROM
 	members
 WHERE
-	guild_id = $1 AND (
-		data->'user'->>'global_name' ilike $2 OR
-		data->'user'->>'display_name' ilike $2 OR
-		data->'user'->>'username' ilike $2 OR
-		data->>'nick' ilike $2
-	)
+	guild_id = $1
+	AND lower(
+		coalesce(data->'user'->>'global_name', '') || ' ' ||
+		coalesce(data->'user'->>'display_name', '') || ' ' ||
+		coalesce(data->'user'->>'username', '') || ' ' ||
+		coalesce(data->>'nick', '')
+	) LIKE lower('%' || $2 || '%')
 `
 
 	var ms []RawJSON
-	err := db.sql.SelectContext(ctx, &ms, q, guildID, "%"+query+"%")
+	err := db.sql.SelectContext(ctx, &ms, q, guildID, query)
 	if err != nil {
 		return nil, xerrors.Errorf("exec select: %w", err)
 	}

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -307,11 +307,11 @@ WHERE
 		coalesce(data->'user'->>'display_name', '') || ' ' ||
 		coalesce(data->'user'->>'username', '') || ' ' ||
 		coalesce(data->>'nick', '')
-	) LIKE lower('%' || $2 || '%')
+	) LIKE $2
 `
 
 	var ms []RawJSON
-	err := db.sql.SelectContext(ctx, &ms, q, guildID, query)
+	err := db.sql.SelectContext(ctx, &ms, q, guildID, "%"+strings.ToLower(query)+"%")
 	if err != nil {
 		return nil, xerrors.Errorf("exec select: %w", err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -50,7 +50,7 @@ type DB interface {
 	GetGuildMembers(ctx context.Context, guild int64) ([][]byte, error)
 	GetGuildMembersWithRole(ctx context.Context, guild, role int64) ([][]byte, error)
 	DeleteGuildMember(ctx context.Context, guild, user int64) error
-	SearchGuildMembers(ctx context.Context, guildID int64, query string) ([][]byte, error)
+	SearchGuildMembers(ctx context.Context, guildID int64, query string, limit int) ([][]byte, error)
 	SetPresence(ctx context.Context, guild, user int64, raw []byte) error
 	GetUserPresence(ctx context.Context, guildID, userID int64) ([]byte, error)
 	SetPresences(ctx context.Context, guildID int64, presences map[int64][]byte) error


### PR DESCRIPTION
## Summary

- Replace sequential `ILIKE` member search with a `pg_trgm` GIN index on a concatenated, lowercased name string, enabling index-assisted trigram matching
- Fix `GetUser` to order by `guild_id DESC` (exploits the composite PK index) instead of `last_updated DESC` (required a seq scan / extra index)
- Remove the now-redundant `members_guild_id` standalone index

## Test plan

- [x] Deploy migration (`CREATE EXTENSION pg_trgm`, `CREATE INDEX CONCURRENTLY members_search_trgm`) against staging DB
- [x] Verify `SearchGuildMembers` query uses the new GIN index (`EXPLAIN ANALYZE`)
- [x] Verify `GetUser` query uses PK index (`EXPLAIN ANALYZE`)
- [x] Smoke-test member search and user lookup via State Cache API

🤖 Generated with [Claude Code](https://claude.com/claude-code)