### PR TITLE
gateway: timing wrapper for divergence DB read

### DIFF
--- a/internal/gatewayws/divergence_timing.go
+++ b/internal/gatewayws/divergence_timing.go
@@ -1,0 +1,79 @@
+package gatewayws
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cdr.dev/slog"
+)
+
+// DivergenceTiming records per-call durations for the divergence
+// check's DB read. Shared across shards in a process so summary logs
+// fire at a manageable rate instead of once per shard.
+type DivergenceTiming struct {
+	log          slog.Logger
+	slowThresh   time.Duration
+	summaryEvery int64
+
+	mu        sync.Mutex
+	count     int64
+	sumNanos  int64
+	maxNanos  int64
+	slowCount int64
+}
+
+func NewDivergenceTiming(log slog.Logger, slowThresh time.Duration, summaryEvery int64) *DivergenceTiming {
+	if summaryEvery <= 0 {
+		summaryEvery = 1000
+	}
+	return &DivergenceTiming{
+		log:          log,
+		slowThresh:   slowThresh,
+		summaryEvery: summaryEvery,
+	}
+}
+
+func (t *DivergenceTiming) record(ctx context.Context, dur time.Duration) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	t.count++
+	t.sumNanos += int64(dur)
+	if int64(dur) > t.maxNanos {
+		t.maxNanos = int64(dur)
+	}
+	slow := t.slowThresh > 0 && dur >= t.slowThresh
+	if slow {
+		t.slowCount++
+	}
+	emitSummary := t.count%t.summaryEvery == 0
+
+	var (
+		summaryCount, summaryMaxN, summarySlow int64
+		summaryMean                            time.Duration
+	)
+	if emitSummary {
+		summaryCount = t.count
+		summaryMaxN = t.maxNanos
+		summarySlow = t.slowCount
+		summaryMean = time.Duration(t.sumNanos / t.count)
+	}
+	t.mu.Unlock()
+
+	if slow {
+		t.log.Warn(ctx, "divergence DB call slow",
+			slog.F("duration", dur.String()),
+			slog.F("threshold", t.slowThresh.String()))
+	}
+	if emitSummary {
+		t.log.Info(ctx, "divergence DB timing summary",
+			slog.F("count", summaryCount),
+			slog.F("mean", summaryMean.String()),
+			slog.F("max", time.Duration(summaryMaxN).String()),
+			slog.F("slow_count", summarySlow),
+			slog.F("slow_threshold", t.slowThresh.String()))
+	}
+}

--- a/internal/gatewayws/divergence_timing_test.go
+++ b/internal/gatewayws/divergence_timing_test.go
@@ -1,0 +1,43 @@
+package gatewayws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cdr.dev/slog"
+)
+
+func TestDivergenceTiming_RecordIncrementsCounters(t *testing.T) {
+	dt := NewDivergenceTiming(slog.Logger{}, 100*time.Millisecond, 1000)
+	dt.record(context.Background(), 5*time.Millisecond)
+	dt.record(context.Background(), 200*time.Millisecond)
+	dt.record(context.Background(), 50*time.Millisecond)
+
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	if dt.count != 3 {
+		t.Fatalf("count: got %d want 3", dt.count)
+	}
+	if dt.slowCount != 1 {
+		t.Fatalf("slowCount: got %d want 1 (only the 200ms call)", dt.slowCount)
+	}
+	if dt.maxNanos != int64(200*time.Millisecond) {
+		t.Fatalf("maxNanos: got %d want %d", dt.maxNanos, int64(200*time.Millisecond))
+	}
+}
+
+func TestDivergenceTiming_NilSafe(t *testing.T) {
+	var dt *DivergenceTiming
+	dt.record(context.Background(), 10*time.Millisecond) // must not panic
+}
+
+func TestDivergenceTiming_NoSlowThreshold(t *testing.T) {
+	dt := NewDivergenceTiming(slog.Logger{}, 0, 1000)
+	dt.record(context.Background(), 500*time.Millisecond)
+	dt.mu.Lock()
+	defer dt.mu.Unlock()
+	if dt.slowCount != 0 {
+		t.Fatalf("slow threshold 0 should disable slow tracking; got %d", dt.slowCount)
+	}
+}

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -111,7 +111,8 @@ type Session struct {
 	// Members op is sent on GUILD_CREATE. 0 disables the check (always
 	// request, current pre-Phase-3 behavior). Cold guilds always
 	// request regardless.
-	divergenceRatio float64
+	divergenceRatio  float64
+	divergenceTiming *DivergenceTiming
 
 	chunks *chunkTracker
 }
@@ -184,6 +185,9 @@ type SessionConfig struct {
 	// DivergenceRatio gates GUILD_CREATE-time member backfill. See
 	// Session.divergenceRatio.
 	DivergenceRatio float64
+	// DivergenceTiming, when non-nil, records per-call durations for
+	// the divergence DB read. Shared across shards in a process.
+	DivergenceTiming *DivergenceTiming
 }
 
 func NewSession(cfg *SessionConfig) (*Session, error) {
@@ -226,6 +230,7 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 		stabilizeUseDrain:    cfg.StabilizeUseDrain,
 		identifyPacing:       pacing,
 		divergenceRatio:      cfg.DivergenceRatio,
+		divergenceTiming:     cfg.DivergenceTiming,
 
 		chunks: newChunkTracker(),
 	}
@@ -273,7 +278,9 @@ func (s *Session) shouldRequestMembersForGuild(ctx context.Context, p *handler.E
 	if p.DiscordMemberCount <= 0 {
 		return true
 	}
+	start := time.Now()
 	cached, err := s.stateDB.GetGuildMemberCount(ctx, p.GuildID)
+	s.divergenceTiming.record(ctx, time.Since(start))
 	if err != nil {
 		s.log.Warn(s.ctx, "divergence check: GetGuildMemberCount failed, falling through to request",
 			slog.F("guild", p.GuildID), slog.Error(err))

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -47,6 +47,7 @@ type Manager struct {
 	stabilizeUseDrain    bool
 	identifyPacing       time.Duration
 	divergenceRatio      float64
+	divergenceTiming     *gatewayws.DivergenceTiming
 
 	sweepEnabled        bool
 	sweepRequestsPerSec int
@@ -215,6 +216,13 @@ func New(ctx context.Context, cfg *Config) *Manager {
 	// validated. Until then, behavior matches pre-Phase-3 — every
 	// GUILD_CREATE triggers a Request Guild Members.
 	divergenceRatio := envFloat(cfg.Logger, ctx, "BACKFILL_DIVERGENCE_RATIO", 0)
+	divergenceSlowMS := envInt(cfg.Logger, ctx, "BACKFILL_DIVERGENCE_TIMING_SLOW_MS", 100)
+	divergenceSummaryEvery := envInt(cfg.Logger, ctx, "BACKFILL_DIVERGENCE_TIMING_SUMMARY_CALLS", 1000)
+	divergenceTiming := gatewayws.NewDivergenceTiming(
+		cfg.Logger,
+		time.Duration(divergenceSlowMS)*time.Millisecond,
+		int64(divergenceSummaryEvery),
+	)
 	sweepEnabled := os.Getenv("BACKFILL_SWEEP_ENABLED") != "false"
 	sweepRPS := envInt(cfg.Logger, ctx, "BACKFILL_SWEEP_REQUESTS_PER_SECOND", 12)
 	sweepBatch := envInt(cfg.Logger, ctx, "BACKFILL_SWEEP_BATCH", 200)
@@ -230,6 +238,8 @@ func New(ctx context.Context, cfg *Config) *Manager {
 		slog.F("stabilize_floor", stabilizeDuration.String()),
 		slog.F("stabilize_max", stabilizeMax.String()),
 		slog.F("divergence_ratio", divergenceRatio),
+		slog.F("divergence_slow_ms", divergenceSlowMS),
+		slog.F("divergence_summary_calls", divergenceSummaryEvery),
 		slog.F("sweep_enabled", sweepEnabled),
 		slog.F("sweep_rps", sweepRPS),
 		slog.F("sweep_batch", sweepBatch))
@@ -264,6 +274,7 @@ func New(ctx context.Context, cfg *Config) *Manager {
 		stabilizeUseDrain:    stabilizeUseDrain,
 		identifyPacing:       identifyPacing,
 		divergenceRatio:      divergenceRatio,
+		divergenceTiming:     divergenceTiming,
 
 		sweepEnabled:        sweepEnabled,
 		sweepRequestsPerSec: sweepRPS,
@@ -311,6 +322,7 @@ func (m *Manager) startShard(shard int) {
 		StabilizeUseDrain:    m.stabilizeUseDrain,
 		IdentifyPacing:       m.identifyPacing,
 		DivergenceRatio:      m.divergenceRatio,
+		DivergenceTiming:     m.divergenceTiming,
 	})
 	if err != nil {
 		m.log.Error(m.ctx, "make gateway session", slog.Error(err))


### PR DESCRIPTION
## Summary

Adds lightweight in-process timing around the divergence check's `GetGuildMemberCount` DB call so ops can gauge `count(*)` cost at scale before enabling `BACKFILL_DIVERGENCE_RATIO`.

Builds on top of #69.

## What

- Wraps `s.stateDB.GetGuildMemberCount(...)` in `shouldRequestMembersForGuild` with `time.Since`.
- A shared `DivergenceTiming` (one instance per process, passed to every shard) records `count`, `sum`, `max`, and `slow_count` under a single mutex.
- Per-call WARN log when a call exceeds the configured slow threshold.
- Periodic INFO log with `count / mean / max / slow_count / threshold` every N calls.

Zero cost when divergence is disabled (`BACKFILL_DIVERGENCE_RATIO=0`, the default) — the divergence branch returns before the DB read, so the timing call never fires.

## Env vars

| Var | Default | Purpose |
|---|---|---|
| `BACKFILL_DIVERGENCE_TIMING_SLOW_MS` | 100 | Per-call WARN threshold |
| `BACKFILL_DIVERGENCE_TIMING_SUMMARY_CALLS` | 1000 | Emit summary log every N calls |

## Usage pattern

1. Enable in a canary shard range: `BACKFILL_DIVERGENCE_RATIO=0.05`.
2. Watch logs for `divergence DB timing summary` lines — confirms mean/max are under your latency budget.
3. Watch for `divergence DB call slow` warnings — none expected in steady state.
4. If both look good, roll wider.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] New unit tests: counter increments, nil-safe record, slow threshold of 0 disables slow tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)
