### PR TITLE
feat: skip redundant REQUEST_GUILD_MEMBERS on reidentify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,8 @@ Discord WS → gatewayws.Session → handler.Client → state.DB (store) → Man
 - `internal/manager/` — Multi-shard orchestration, Redis event routing, gRPC management server
 - `handler/` — Discord event processing (guild, channel, member, message, role, emoji, thread events)
 - `internal/state/` — `state.DB` interface (~93 methods) abstracting storage backends
-- `internal/state/db/statefdb/` — FoundationDB implementation (primary)
-- `internal/state/db/statepsql/` — PostgreSQL implementation (fallback)
+- `internal/state/db/statepsql/` — PostgreSQL implementation (**primary / source of truth**)
+- `internal/state/db/statefdb/` — FoundationDB implementation (legacy; data is stale, several methods are `panic("unimplemented")`, do not trust as source of truth for cache-dependent optimizations)
 - `internal/state/api/` — REST API handlers for state queries (fasthttp + httprouter)
 - `discord/discordetf/` — Custom ETF (Erlang Term Format) encoder/decoder built from scratch
 - `discord/discordjson/` — JSON encoding alternative
@@ -123,9 +123,9 @@ Discord WS → gatewayws.Session → handler.Client → state.DB (store) → Man
 - `SHARDS` — Total shard count
 - `START`/`STOP` — Shard range (inclusive/exclusive)
 - `INTENTS` — Discord intent set: `default`, `all`, `fast`
-- `PSQL` — PostgreSQL address (fallback; otherwise uses FoundationDB)
+- `PSQL` — PostgreSQL address (primary store)
 - `PROD` — Enables production logging (JSON/stackdriver vs human-readable)
 
 ## Dependencies
 
-Requires FoundationDB client libraries (v6.2.27) installed on the system. Redis and etcd must be available at runtime.
+Requires PostgreSQL at runtime (primary store). Redis and etcd must also be available. FoundationDB client libraries (v6.2.27) are still required to build, but the FDB backend is legacy and not actively maintained — new optimizations that depend on cached state being accurate should target PSQL and have FDB fall back to the slow path.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as time permits.
 
 A custom ETF parser was written from the ground up. During peak traffic, gateway uses ~4 cores for 720 shards.
 
-State is stored in [foundationdb](https://www.foundationdb.org/) and accessed via the State Cache (cmd/state).
+State is stored in [PostgreSQL](https://www.postgresql.org/) and accessed via the State Cache (cmd/state). A [FoundationDB](https://www.foundationdb.org/) backend also exists in `internal/state/db/statefdb/` but is legacy and no longer the source of truth.
 
 Events are pushed to [redis](https://redis.io) using `RPUSH`. The content is the `d` key of the event encoded as ETF.
 

--- a/docs/superpowers/specs/2026-04-30-faster-mass-reconnect-design.md
+++ b/docs/superpowers/specs/2026-04-30-faster-mass-reconnect-design.md
@@ -1,0 +1,195 @@
+# Faster Gateway Mass Reconnect
+
+Status: Design
+
+## Problem
+
+When many shards must re-IDENTIFY simultaneously (Discord-side outage long enough to invalidate sessions, or any scenario that pushes most shards off the resume path), wall-clock time to fully re-identify ~720 shards is dominated by an internal serialization, not Discord's identify rate limit.
+
+Today, `Open()` on a fresh identify acquires an etcd mutex bucketed by `shardID % 16`, then holds that mutex from before the WebSocket dial through 70s after READY (10s `IdentifyWaitTime` + 60s `IdentifyStabilizeTime` when the GuildMembers intent is on). With 720 shards across 16 buckets, that's ~45 serial identifies per bucket × 70s ≈ **52 minutes worst case**.
+
+Discord's identify rate limit (5s per `max_concurrency` slot) would otherwise allow ~7.5 minutes for the same workload at 16 concurrent buckets.
+
+The internal 60s `IdentifyStabilizeTime` exists to "let the DB catch up" while a shard's GUILD_CREATE → `Request Guild Members` → `GUILD_MEMBER_CHUNK` backfill drains. It is currently coupled to identify pacing and to the `IntentGuildMembers` flag, even though those are independent concerns. The `state.DB` PostgreSQL backend already has a sharded, deduping batcher (`internal/state/db/statepsql/batcher.go`) that absorbs hot-key bursts; whether the 60s wait is still load-bearing has not been measured. There is also no full-resync mechanism today, so backfill on every reconnect is the only thing keeping member rosters from drifting.
+
+The "fast intents" deployment mode reconnects in ~15 minutes precisely because it sets `hasGuildMembersIntent = false`, which makes `calcIdentifyWait()` skip the 60s wait. The ops cost is dropping intents that the consumers actually want — i.e., it solves reconnect time by giving up correctness.
+
+## Goals
+
+- Reduce wall-clock time for an identify-storm reconnect of ~720 shards from ~50 minutes toward Discord's identify-throughput floor (~7–8 minutes at the current 16 buckets).
+- Keep Discord's 5s-per-bucket identify pacing honored.
+- Keep the existing safety property that DB writes don't get hammered by simultaneous member-chunk bursts from many shards — but make that a separate, measurable mechanism instead of a fixed wall inside the identify lock.
+- Bound member-roster drift without forcing a full backfill on every reconnect.
+- No behavioral change in the resume path. It already skips the lock; leave it alone.
+
+## Non-Goals
+
+- Replacing the etcd mutex with an in-process semaphore. Single-pod-per-shard-range makes it feasible, but it's a separate cleanup.
+- Auto-discovering Discord `max_concurrency` from `/gateway/bot`. The 16-bucket constant is hardcoded as `s.shardID % 16`; making it dynamic is orthogonal mechanical work.
+- Touching the manager-loop 1s sleep between reconnect attempts.
+- Changing persistence (sessID/seq/resumeURL) to keep more shards on the resume path. Different problem (transient-blip scenario).
+- Two-phase identify (FastIntents first, full intents second). Doubles identify count and creates an event-loss window; rejected.
+
+## Architecture
+
+### Today
+
+```
+Open()
+  loadSeq/sessID/resumeURL
+  initEtcd (lease, 70s TTL)
+  acquireIdentifyLock (mod-16 bucket)        ─┐ lock held
+    dial WS                                   │ throughout
+    readHello                                 │ ~70s
+    writeIdentify                             │
+    READY received                            │
+    goroutine sleeps 70s → releaseIdentifyLock┘
+    handle events…
+```
+
+The mutex covers the dial, hello exchange, identify, AND the 60s post-READY stabilize wait. Whatever is the slowest step inside that window holds up every other shard in the same bucket.
+
+### Proposed
+
+```
+Open()
+  loadSeq/sessID/resumeURL
+  initEtcd
+  dial WS                          ─┐ MOVED outside lock (Phase 1, Approach 2)
+  readHello                         │
+  acquireIdentifyLock (mod-N bucket)─┐ lock held only for
+    writeIdentify                    │ Discord's pacing window
+    wait for READY (with grace)      │ (~5–10s)
+  releaseIdentifyLock               ─┘
+  if shouldRequestMembers(guild):     ← per-guild decision, Phase 3a
+     acquire stabilize semaphore     ─┐ separate gate, Phase 1
+     wait for backfill drain          │ (chunk-count signal, Phase 2)
+     release stabilize semaphore      │
+  handle events…
+```
+
+Two new mechanisms replace the single overloaded mutex:
+
+**Identify lock** — same etcd mutex (`/gateway/identify/<bucket>`), but holds only across `writeIdentify` → READY-or-pacing-elapsed. Released as soon as the shard is past the rate-limit-relevant step.
+
+**DB-stabilization gate** — separate in-process weighted semaphore (no etcd involvement, single-pod confirmed). Capacity defaults to 1 (matches current behavior — one stabilizing shard at a time). Knob: `IDENTIFY_STABILIZE_CONCURRENCY`. Wait policy in Phase 1 is a fixed `IDENTIFY_STABILIZE_SECONDS` defaulting to 60s; replaced in Phase 2 by chunk-drain signal.
+
+### Conditional backfill
+
+`shouldRequestMembers(guild)` in Phase 3a replaces today's blanket `shouldProcessMembers()` check at GUILD_CREATE. Decision rule:
+
+```
+should_request_members(guild) =
+    !skipMemberRequest
+    && hasGuildMembersIntent
+    && (
+        last_backfilled_at IS NULL                          // cold guild
+        OR now - last_backfilled_at > STALENESS_THRESHOLD   // stale
+        OR abs(discord_member_count - cached_count)
+              / discord_member_count > DIVERGENCE_THRESHOLD // divergent
+    )
+```
+
+Triggers:
+
+| Trigger | Why | Default |
+|---|---|---|
+| Cold | First contact after fresh DB; no cached roster | always |
+| Stale | Bound roster drift over time | 24h |
+| Divergent | Catch silent drift between scheduled refreshes | 5% |
+
+Backfill completion: when `chunk_index == chunk_count - 1` for a guild's `GUILD_MEMBER_CHUNK`, write `last_backfilled_at = now` to that guild's row. Per-shard in-memory map tracks in-flight backfills (`guild_id → expected_chunks`).
+
+### Background re-sync sweep (Phase 3b)
+
+One goroutine per process (in the manager, not per shard) walks `state.DB` periodically:
+
+- Tick every `BACKFILL_SWEEP_INTERVAL` (default 1h).
+- Find guilds where `last_backfilled_at < now - STALENESS_THRESHOLD` AND not currently in-flight.
+- For each, look up the shard that owns the guild (`(guildID >> 22) % shardCount`) and route a `Request Guild Members` op through that shard's session.
+- Pace at `BACKFILL_REQUESTS_PER_SECOND` (default 2/s) globally to avoid a thundering herd on Discord and the DB batcher.
+
+The sweep decouples staleness-driven re-sync from the connect path entirely. After Phase 3b lands, the connect-path conditional check in Phase 3a only catches **cold** and **divergent** guilds; routine staleness is the sweep's job.
+
+### Failure handling
+
+- **Pre-lock dial failure** — discard the connection, no lock held, retry from the top. (Today's flow holds the lock during a failed dial too; new flow is strictly cheaper for failures.)
+- **Lock acquired, READY never arrives** — time out at `IdentifyWaitTime + grace` (configurable, default 5s grace), release lock, fall through to retry. Avoids one bad shard wedging a bucket for the full etcd lease TTL.
+- **Stabilize semaphore acquired, drain never completes** — time out at `IDENTIFY_STABILIZE_SECONDS_MAX` (default 120s, 2× current 60s ceiling), release semaphore, log a warning, continue. We never block forever on the stabilize gate.
+- **Resume path** — unchanged. Skips both the lock and the stabilize gate.
+- **Sweep request to a disconnected shard** — drop silently; sweep will pick the guild up next tick once the shard reconnects.
+
+### Components and ownership
+
+| Component | Lives in | Responsibility |
+|---|---|---|
+| Identify lock (etcd mutex) | `internal/gatewayws` | Discord identify pacing, mod-N bucket |
+| Stabilize semaphore | `internal/manager` (shared across shards) | Cap concurrent backfill bursts hitting `state.DB` |
+| Backfill metadata column | `state.DB` schema (psql + fdb) | Per-guild `last_backfilled_at` |
+| Conditional check | `gatewayws.Session` GUILD_CREATE branch in `Open()` | Decide whether to call `requestGuildMembers`; reads `last_backfilled_at` and `member_count` via `state.DB` |
+| Chunk-drain tracker | `gatewayws.Session` | Map of in-flight guild → expected/received chunks |
+| Background sweep | `internal/manager` | Periodic staleness scan, route to shards |
+
+Schema delta:
+
+```sql
+ALTER TABLE guilds ADD COLUMN last_backfilled_at timestamp NULL;
+CREATE INDEX guilds_last_backfilled_at ON guilds (last_backfilled_at)
+    WHERE last_backfilled_at IS NOT NULL;
+```
+
+The partial index supports the sweep's "find stale guilds" query without bloating writes for cold guilds.
+
+The corresponding FoundationDB representation stores the timestamp in the same guild key's value blob (or as a sibling key under the guild prefix — implementation detail for the FDB backend).
+
+## Observability
+
+New metrics needed before tuning the knobs:
+
+- `gateway_identify_lock_wait_seconds` — time from `acquireIdentifyLock` call to acquired
+- `gateway_identify_lock_held_seconds` — time lock is actually held (target: shrinks dramatically)
+- `gateway_stabilize_wait_seconds` — time spent in stabilize semaphore
+- `gateway_backfill_chunks_received_total{guild_id}` — counter
+- `gateway_backfill_drain_seconds` — time from `requestGuildMembers` send to last chunk for a guild
+- `gateway_backfill_skipped_total{reason}` — `cold|stale|divergent|fresh|disabled`
+- `gateway_sweep_guilds_resynced_total`
+- `gateway_sweep_queue_depth`
+- `state_db_batcher_queue_depth{event_type}` — already exists or can be added; needed to validate the batcher absorbs the load
+
+## Phasing
+
+**Phase 1 — Lock shrink + decoupled stabilize gate.**
+
+Move dial + hello before lock acquisition. Reduce lock scope to identify-send through READY-or-pacing-grace. Add stabilize semaphore in `internal/manager` with `IDENTIFY_STABILIZE_CONCURRENCY` (default 1) and `IDENTIFY_STABILIZE_SECONDS` (default 60). Add the metrics above. Behavior is identical for `SKIP_MEMBER_REQUEST=true` deploys; mass identify becomes ~7× faster for prod's `SKIP_MEMBER_REQUEST=false` deploy because the stabilize wait runs in parallel with the next shard's identify rather than serializing it.
+
+**Phase 2 — Drain-based stabilize signal.**
+
+Replace the fixed `IDENTIFY_STABILIZE_SECONDS` with the chunk-drain tracker. Stabilize is "done" when this shard's outstanding chunk count is zero AND the batcher queue depth is below a threshold. Keeps the upper-bound timeout from Phase 1 as a safety. After this lands, the stabilize semaphore caps concurrent draining shards (still default 1) but the per-shard wait is "as long as actually needed."
+
+**Phase 3a — Conditional backfill at GUILD_CREATE.**
+
+Add `last_backfilled_at` column. Implement `shouldRequestMembers(guild)` with cold/stale/divergent triggers. Introduce env knobs: `BACKFILL_STALENESS_HOURS` (default 24), `BACKFILL_DIVERGENCE_RATIO` (default 0.05). Steady-state mass identify on an already-populated DB now skips most member requests entirely — reconnect approaches the Discord-floor lower bound.
+
+**Phase 3b — Background re-sync sweep.**
+
+Implement the manager-level goroutine. Knobs: `BACKFILL_SWEEP_INTERVAL` (default 1h), `BACKFILL_REQUESTS_PER_SECOND` (default 2). Sweep takes over staleness-driven re-syncs; Phase 3a's connect-path check then only fires for cold + divergent guilds.
+
+Each phase is independently shippable. Phase 1 is the structural change; Phases 2 and 3 progressively reduce the stabilize wait toward zero in steady state.
+
+## Expected impact
+
+| Phase | Mass identify of 720 shards | Notes |
+|---|---|---|
+| Today | ~50 min | 45 × 70s, lock dominates |
+| Phase 1, default config | ~45 min | Stabilize runs in parallel with subsequent identifies, but with `IDENTIFY_STABILIZE_CONCURRENCY=1` the stabilize gate becomes the new serial bottleneck (~45 × 60s). Phase 1 alone is mostly about unlocking the tuning surface, not shipping a smaller wall. |
+| Phase 1 + concurrency raised | ~10–15 min | Once metrics confirm the batcher absorbs N concurrent draining shards, raise `IDENTIFY_STABILIZE_CONCURRENCY`. With N=4 → ~12 min; N=8 → ~7.5 min (Discord-floor). |
+| Phase 2 | ~7.5–10 min typical | Drain signal beats fixed 60s for most guilds; concurrency knob still applies |
+| Phase 3a + 3b (steady state) | ~7.5 min (Discord floor) | Most guilds skip backfill entirely; sweep handles staleness out-of-band |
+
+## Open questions
+
+None blocking. Items deferred to implementation:
+
+- Exact metric names + label cardinality (member chunk metrics keyed by guild_id may need sampling).
+- FoundationDB representation of `last_backfilled_at` (existing guild value vs sibling key).
+- Whether to expose stabilize-semaphore tuning via the existing gRPC management API for live ops.

--- a/docs/superpowers/specs/2026-04-30-faster-mass-reconnect-design.md
+++ b/docs/superpowers/specs/2026-04-30-faster-mass-reconnect-design.md
@@ -90,6 +90,14 @@ should_request_members(guild) =
     )
 ```
 
+> **Implementation status (this PR):** the `last_backfilled_at` column and the
+> staleness/divergence arms above are not yet built. The first increment ships
+> the cold-guild arm only, using a `GuildHasMembers(guild)` `EXISTS` check
+> (`SELECT EXISTS(SELECT 1 FROM members WHERE guild_id = $1)`) as a proxy for
+> `last_backfilled_at IS NULL`: if any members are already cached we skip RGM on
+> this connect cycle, otherwise we request. The schema change and the
+> stale/divergent arms land in a follow-up.
+
 Triggers:
 
 | Trigger | Why | Default |

--- a/handler/guild.go
+++ b/handler/guild.go
@@ -8,14 +8,23 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, error) {
+func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, bool, error) {
 	gc, err := c.enc.DecodeGuildCreate(d)
 	if err != nil {
-		return 0, 0, xerrors.Errorf("parse guild create: %w", err)
+		return 0, 0, false, xerrors.Errorf("parse guild create: %w", err)
 	}
 
 	guild := gc.ID
 	memberCount := gc.MemberCount
+
+	// Check whether members already exist for this guild before the errgroup
+	// writes the initial slice. A true result implies a prior backfill in an
+	// earlier session, so RGM is unnecessary on this connect cycle.
+	hadMembers, herr := c.db.GuildHasMembers(ctx, guild)
+	if herr != nil {
+		// Fail-safe: on uncertainty, treat as not-backfilled so RGM still fires.
+		hadMembers = false
+	}
 
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
@@ -99,7 +108,7 @@ func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, error
 		return nil
 	})
 	err = eg.Wait()
-	return guild, memberCount, err
+	return guild, memberCount, hadMembers, err
 }
 
 func (c *Client) GuildDelete(ctx context.Context, d []byte) error {

--- a/handler/guild.go
+++ b/handler/guild.go
@@ -8,13 +8,14 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, error) {
+func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, error) {
 	gc, err := c.enc.DecodeGuildCreate(d)
 	if err != nil {
-		return 0, xerrors.Errorf("parse guild create: %w", err)
+		return 0, 0, xerrors.Errorf("parse guild create: %w", err)
 	}
 
 	guild := gc.ID
+	memberCount := gc.MemberCount
 
 	eg := new(errgroup.Group)
 	eg.Go(func() error {
@@ -98,7 +99,7 @@ func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, error) {
 		return nil
 	})
 	err = eg.Wait()
-	return guild, err
+	return guild, memberCount, err
 }
 
 func (c *Client) GuildDelete(ctx context.Context, d []byte) error {

--- a/handler/guild.go
+++ b/handler/guild.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"cdr.dev/slog"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 )
@@ -23,6 +24,10 @@ func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, int, 
 	// earlier session, so RGM is unnecessary on this connect cycle.
 	hadMembers, herr := c.db.GuildHasMembers(ctx, guild)
 	if herr != nil {
+		// Fail safe: assume no prior backfill and let RGM run. Log it so a
+		// consistently-failing check (which would silently negate this
+		// optimization during mass reconnects) is diagnosable.
+		c.log.Warn(ctx, "GuildHasMembers check failed; defaulting to RGM", slog.Error(herr), slog.F("guild", guild))
 		hadMembers = false
 	}
 

--- a/handler/guild.go
+++ b/handler/guild.go
@@ -8,21 +8,21 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, bool, error) {
+func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, int, bool, error) {
 	gc, err := c.enc.DecodeGuildCreate(d)
 	if err != nil {
-		return 0, 0, false, xerrors.Errorf("parse guild create: %w", err)
+		return 0, 0, 0, false, xerrors.Errorf("parse guild create: %w", err)
 	}
 
 	guild := gc.ID
 	memberCount := gc.MemberCount
+	receivedMemberCount := len(gc.Members)
 
 	// Check whether members already exist for this guild before the errgroup
 	// writes the initial slice. A true result implies a prior backfill in an
 	// earlier session, so RGM is unnecessary on this connect cycle.
 	hadMembers, herr := c.db.GuildHasMembers(ctx, guild)
 	if herr != nil {
-		// Fail-safe: on uncertainty, treat as not-backfilled so RGM still fires.
 		hadMembers = false
 	}
 
@@ -108,7 +108,7 @@ func (c *Client) GuildCreate(ctx context.Context, d []byte) (int64, int64, bool,
 		return nil
 	})
 	err = eg.Wait()
-	return guild, memberCount, hadMembers, err
+	return guild, memberCount, receivedMemberCount, hadMembers, err
 }
 
 func (c *Client) GuildDelete(ctx context.Context, d []byte) error {

--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -9,7 +9,8 @@ import (
 )
 
 type EventPayload struct {
-	GuildID int64
+	GuildID     int64
+	MemberCount int64
 }
 
 func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPayload, error) {
@@ -21,10 +22,10 @@ func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPaylo
 	case "PRESENCE_UPDATE":
 		return nil, c.PresenceCreate(ctx, e.D)
 	case "GUILD_CREATE":
-		guildId, err := c.GuildCreate(ctx, e.D)
-		return &EventPayload{GuildID: guildId}, err
+		guildId, memberCount, err := c.GuildCreate(ctx, e.D)
+		return &EventPayload{GuildID: guildId, MemberCount: memberCount}, err
 	case "GUILD_UPDATE":
-		guildId, err := c.GuildCreate(ctx, e.D)
+		guildId, _, err := c.GuildCreate(ctx, e.D)
 		return &EventPayload{GuildID: guildId}, err
 	case "GUILD_DELETE":
 		return nil, c.GuildDelete(ctx, e.D)

--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -11,6 +11,7 @@ import (
 type EventPayload struct {
 	GuildID     int64
 	MemberCount int64
+	HadMembers  bool
 }
 
 func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPayload, error) {
@@ -22,10 +23,10 @@ func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPaylo
 	case "PRESENCE_UPDATE":
 		return nil, c.PresenceCreate(ctx, e.D)
 	case "GUILD_CREATE":
-		guildId, memberCount, err := c.GuildCreate(ctx, e.D)
-		return &EventPayload{GuildID: guildId, MemberCount: memberCount}, err
+		guildId, memberCount, hadMembers, err := c.GuildCreate(ctx, e.D)
+		return &EventPayload{GuildID: guildId, MemberCount: memberCount, HadMembers: hadMembers}, err
 	case "GUILD_UPDATE":
-		guildId, _, err := c.GuildCreate(ctx, e.D)
+		guildId, _, _, err := c.GuildCreate(ctx, e.D)
 		return &EventPayload{GuildID: guildId}, err
 	case "GUILD_DELETE":
 		return nil, c.GuildDelete(ctx, e.D)

--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -9,9 +9,10 @@ import (
 )
 
 type EventPayload struct {
-	GuildID     int64
-	MemberCount int64
-	HadMembers  bool
+	GuildID              int64
+	MemberCount          int64
+	ReceivedMemberCount  int
+	HadMembers           bool
 }
 
 func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPayload, error) {
@@ -23,10 +24,10 @@ func (c *Client) HandleEvent(ctx context.Context, e *discord.Event) (*EventPaylo
 	case "PRESENCE_UPDATE":
 		return nil, c.PresenceCreate(ctx, e.D)
 	case "GUILD_CREATE":
-		guildId, memberCount, hadMembers, err := c.GuildCreate(ctx, e.D)
-		return &EventPayload{GuildID: guildId, MemberCount: memberCount, HadMembers: hadMembers}, err
+		guildId, memberCount, receivedMemberCount, hadMembers, err := c.GuildCreate(ctx, e.D)
+		return &EventPayload{GuildID: guildId, MemberCount: memberCount, ReceivedMemberCount: receivedMemberCount, HadMembers: hadMembers}, err
 	case "GUILD_UPDATE":
-		guildId, _, _, err := c.GuildCreate(ctx, e.D)
+		guildId, _, _, _, err := c.GuildCreate(ctx, e.D)
 		return &EventPayload{GuildID: guildId}, err
 	case "GUILD_DELETE":
 		return nil, c.GuildDelete(ctx, e.D)

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -110,7 +110,7 @@ func (s *Session) writeIdentify() {
 				Device:  runtime.Version(),
 			},
 			Compress:       false,
-			LargeThreshold: 250,
+			LargeThreshold: LargeThreshold,
 			Shard:          []int{s.shardID, s.shardCount},
 			Intents:        s.intents.Collect(),
 			Presence: updatePresence{

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -321,13 +321,13 @@ func (s *Session) Open(ctx context.Context, token string) error {
 		// request for guild member info only on GUILD_CREATE events and if the intent is set
 		if s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
 			switch {
-			case evtPayload.MemberCount > 0 && evtPayload.MemberCount <= LargeThreshold:
-				// GUILD_CREATE already contains every member for small guilds.
-				s.log.Debug(s.ctx, "skipping rgm: small guild", slog.F("guild", evtPayload.GuildID), slog.F("member_count", evtPayload.MemberCount))
 			case evtPayload.HadMembers:
-				// Members were already in the store before this GUILD_CREATE landed,
-				// implying a prior RGM backfill — no need to re-fetch.
 				s.log.Debug(s.ctx, "skipping rgm: already backfilled", slog.F("guild", evtPayload.GuildID))
+			case evtPayload.MemberCount > 0 &&
+				evtPayload.MemberCount <= LargeThreshold &&
+				int64(evtPayload.ReceivedMemberCount) >= evtPayload.MemberCount:
+				// All expected members arrived in the GUILD_CREATE payload.
+				s.log.Debug(s.ctx, "skipping rgm: all members in guild create", slog.F("guild", evtPayload.GuildID), slog.F("member_count", evtPayload.MemberCount))
 			default:
 				s.curState = "request guild members"
 				s.log.Debug(s.ctx, "requesting guild members", slog.F("guild", evtPayload.GuildID))

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -320,10 +320,15 @@ func (s *Session) Open(ctx context.Context, token string) error {
 
 		// request for guild member info only on GUILD_CREATE events and if the intent is set
 		if s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
-			if evtPayload.MemberCount > 0 && evtPayload.MemberCount <= LargeThreshold {
+			switch {
+			case evtPayload.MemberCount > 0 && evtPayload.MemberCount <= LargeThreshold:
 				// GUILD_CREATE already contains every member for small guilds.
 				s.log.Debug(s.ctx, "skipping rgm: small guild", slog.F("guild", evtPayload.GuildID), slog.F("member_count", evtPayload.MemberCount))
-			} else {
+			case evtPayload.HadMembers:
+				// Members were already in the store before this GUILD_CREATE landed,
+				// implying a prior RGM backfill — no need to re-fetch.
+				s.log.Debug(s.ctx, "skipping rgm: already backfilled", slog.F("guild", evtPayload.GuildID))
+			default:
 				s.curState = "request guild members"
 				s.log.Debug(s.ctx, "requesting guild members", slog.F("guild", evtPayload.GuildID))
 				s.requestGuildMembers(evtPayload.GuildID)

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -31,6 +31,7 @@ const (
 	IdentifyWaitTime      = 10 * time.Second
 	IdentifyStabilizeTime = 60 * time.Second
 	TimeoutAllowance      = 10 * time.Second
+	LargeThreshold        = 250
 )
 
 var skipMemberRequest = os.Getenv("SKIP_MEMBER_REQUEST") == "true"
@@ -319,9 +320,14 @@ func (s *Session) Open(ctx context.Context, token string) error {
 
 		// request for guild member info only on GUILD_CREATE events and if the intent is set
 		if s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
-			s.curState = "request guild members"
-			s.log.Debug(s.ctx, "requesting guild members", slog.F("guild", evtPayload.GuildID))
-			s.requestGuildMembers(evtPayload.GuildID)
+			if evtPayload.MemberCount > 0 && evtPayload.MemberCount <= LargeThreshold {
+				// GUILD_CREATE already contains every member for small guilds.
+				s.log.Debug(s.ctx, "skipping rgm: small guild", slog.F("guild", evtPayload.GuildID), slog.F("member_count", evtPayload.MemberCount))
+			} else {
+				s.curState = "request guild members"
+				s.log.Debug(s.ctx, "requesting guild members", slog.F("guild", evtPayload.GuildID))
+				s.requestGuildMembers(evtPayload.GuildID)
+			}
 		}
 
 	}

--- a/internal/state/db/statefdb/member.go
+++ b/internal/state/db/statefdb/member.go
@@ -86,9 +86,8 @@ func (db *DB) GetGuildMemberCount(ctx context.Context, guildID int64) (int, erro
 	panic("unimplemented")
 }
 
-func (db *DB) GuildHasMembers(_ context.Context, guild int64) (bool, error) {
-	// FDB store is no longer the live source of truth; defer to RGM.
-	return false, nil
+func (db *DB) GuildHasMembers(ctx context.Context, guild int64) (bool, error) {
+	panic("unimplemented")
 }
 
 func (db *DB) SetPresence(ctx context.Context, guildID, userID int64, data []byte) error {

--- a/internal/state/db/statefdb/member.go
+++ b/internal/state/db/statefdb/member.go
@@ -86,6 +86,11 @@ func (db *DB) GetGuildMemberCount(ctx context.Context, guildID int64) (int, erro
 	panic("unimplemented")
 }
 
+func (db *DB) GuildHasMembers(_ context.Context, guild int64) (bool, error) {
+	// FDB store is no longer the live source of truth; defer to RGM.
+	return false, nil
+}
+
 func (db *DB) SetPresence(ctx context.Context, guildID, userID int64, data []byte) error {
 	panic("unimplemented")
 }

--- a/internal/state/db/statepsql/members.go
+++ b/internal/state/db/statepsql/members.go
@@ -97,6 +97,17 @@ WHERE
 	return c, nil
 }
 
+func (db *db) GuildHasMembers(ctx context.Context, guildID int64) (bool, error) {
+	const q = `SELECT EXISTS(SELECT 1 FROM members WHERE guild_id = $1)`
+
+	var has bool
+	err := db.sql.GetContext(ctx, &has, q, guildID)
+	if err != nil {
+		return false, xerrors.Errorf("exec exists: %w", err)
+	}
+	return has, nil
+}
+
 func (db *db) GetGuildMemberCount(ctx context.Context, guildID int64) (int, error) {
 	const q = `
 SELECT

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -48,6 +48,7 @@ type DB interface {
 	SetGuildMember(ctx context.Context, guild, user int64, raw []byte, isNew bool) error
 	GetGuildMember(ctx context.Context, guild, user int64) ([]byte, error)
 	GetGuildMemberCount(ctx context.Context, guild int64) (int, error)
+	GuildHasMembers(ctx context.Context, guild int64) (bool, error)
 	GetGuildMembers(ctx context.Context, guild int64) ([][]byte, error)
 	GetGuildMembersWithRole(ctx context.Context, guild, role int64) ([][]byte, error)
 	DeleteGuildMember(ctx context.Context, guild, user int64) error


### PR DESCRIPTION
## Summary

Cuts the size of the post-IDENTIFY RGM storm by skipping `REQUEST_GUILD_MEMBERS` for two large classes of guilds where it adds no value:

1. **Small guilds (`member_count <= large_threshold`, i.e. 250):** Discord already includes every member in the `GUILD_CREATE` payload. The RGM is pure waste — it consumes the shared 1.75/s command budget and produces a redundant chunk response.
2. **Large guilds already backfilled in a prior session:** an `EXISTS(SELECT 1 FROM members WHERE guild_id = $1)` check, evaluated *before* `GUILD_CREATE` writes its initial online slice, tells us whether we already have member data from a previous connect cycle. If we do, the existing rows are still in store after the reconnect — re-fetching them via RGM is unnecessary.

At ~1M guilds across 1024 shards, the average shard receives ~1000 `GUILD_CREATE`s during a mass reidentify. With the rate limiter at 1.75/s, draining one RGM per guild takes ~9–10 minutes per shard. Removing the small-guild tail plus the warm-cache large guilds collapses that down to the actual delta: new joins and previously-uncached large guilds.

### Design notes

- `MemberCount` and `HadMembers` are threaded through `handler.EventPayload` so the read loop can decide without re-decoding.
- The EXISTS check runs at the top of `handler.GuildCreate`, before the errgroup writes the initial slice — otherwise EXISTS would trivially be true after the first `GUILD_CREATE` and the gate would defeat itself.
- PSQL implements the real check (`SELECT EXISTS(...)`, single index probe on the `(guild_id, user_id)` PK — not a `COUNT(*)`, deliberately avoiding the landmine from the abandoned faster-mass-reconnect branch).
- FDB's `GuildHasMembers` is `panic("unimplemented")`, consistent with the sibling FDB stubs. PSQL is the live source of truth, and the FDB gateway path is already dead — the adjacent `GetGuildMemberCount` call in `GuildCreate` already panics on the FDB backend, so this method is never reached in practice.
- On DB error, the handler fails safe to `hadMembers = false` so RGM still fires, and logs the error at warn so a consistently-failing check (which would silently negate this optimization during a mass reconnect) is diagnosable.

### Trade-offs

- **Cold-cache reconnects** (fresh deploy, wipe, migration) see `EXISTS=false` everywhere and behave the same as today. No regression, no speedup.
- **Partial-backfill state**: if a previous RGM completed only partially (e.g., a guild has 200 members in store out of 5000), EXISTS still returns true and we skip. Subsequent member ADD/UPDATE/REMOVE events heal drift, but the guild can stay partial until something else forces a re-fetch. Acceptable risk given the alternative is the per-event `COUNT(*)` cost that the abandoned branch hit.
- The pre-write DB hit (~1–2ms on PSQL per `GUILD_CREATE`) is on the reader hot path. Cumulative stall across ~1000 guilds per shard is well under a heartbeat interval; worth confirming with a benchmark before deploying.

### Follow-up consideration: remove the FDB backend

This PR leaves the FDB `GuildHasMembers` as a `panic` rather than implementing it, because FDB is no longer the live source of truth and its `GUILD_CREATE` path is already dead. That points at a larger cleanup that is **out of scope here** and should be its own PR:

- Delete the `internal/state/db/statefdb/` package (~1k lines, ~11 files of mostly-`panic`-stubbed `state.DB` methods).
- Make PSQL the only backend in both `cmd/gateway/main.go` and `cmd/state/main.go` (currently FDB is selected whenever `PSQL` is unset) — which means **every gateway/state deployment must set `PSQL`**, so the deploy/helm side has to be verified first.
- Drop the FoundationDB client build dependency (v6.2.27).

Tracking it separately keeps this optimization shippable and gives the backend removal the deploy-sensitive review it needs.

## Test plan

- [ ] Unit/build: `go build ./...` and `go test ./handler/... ./internal/gatewayws/...` pass locally (integration tests requiring a live Postgres are unaffected by this change).
- [ ] Staging: bring up a shard against staging Discord; confirm `skipping rgm: small guild` and `skipping rgm: already backfilled` debug logs fire on reconnect and that `requestGuildMembers` still fires for new joins.
- [ ] Production canary: deploy to a single instance, observe RGM ops/sec drop on reidentify cycles without member chunks being missed for new guilds.
- [ ] Benchmark: measure `GuildHasMembers` latency on the live PSQL instance under load to confirm sub-2ms per call before fleet-wide rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
