### PR TITLE
fix(docker): restore zlib for czlib after FDB removal

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -3,13 +3,17 @@ FROM golang:1.25
 COPY go.mod go.sum /go/src/github.com/tatsuworks/gateway/
 RUN cd /go/src/github.com/tatsuworks/gateway && go mod download
 
+# zlib is required by github.com/tatsuworks/czlib (CGO zlib-stream decoder),
+# independent of the (removed) FoundationDB client libs.
+RUN apt update && apt install -y zlib1g zlib1g-dev
+
 COPY . /go/src/github.com/tatsuworks/gateway
 ENV GO111MODULE=on
 
 RUN cd /go/src/github.com/tatsuworks/gateway/cmd/gateway && go build -o /go/gateway .
 
 FROM ubuntu:24.04
-RUN apt update && apt install -y adduser
+RUN apt update && apt install -y adduser zlib1g
 
 COPY --from=0 /go/gateway /
 COPY entrypoint-gateway.sh /

--- a/Dockerfile.state
+++ b/Dockerfile.state
@@ -3,13 +3,17 @@ FROM golang:1.25
 COPY go.mod go.sum /go/src/github.com/tatsuworks/gateway/
 RUN cd /go/src/github.com/tatsuworks/gateway && go mod download
 
+# zlib is required by github.com/tatsuworks/czlib (CGO zlib-stream decoder),
+# independent of the (removed) FoundationDB client libs.
+RUN apt update && apt install -y zlib1g zlib1g-dev
+
 COPY . /go/src/github.com/tatsuworks/gateway
 ENV GO111MODULE=on
 
 RUN cd /go/src/github.com/tatsuworks/gateway/cmd/state && go build -o /go/state .
 
 FROM ubuntu:24.04
-RUN apt update && apt install -y adduser
+RUN apt update && apt install -y adduser zlib1g
 
 COPY --from=0 /go/state /
 COPY entrypoint-state.sh /


### PR DESCRIPTION
## What
`#76` (FoundationDB removal) stripped the FDB client-lib apt step from `Dockerfile.gateway` and `Dockerfile.state`. That same `apt install` line also installed `zlib1g zlib1g-dev`, which `github.com/tatsuworks/czlib` (CGO zlib-stream decoder, imported by `internal/gatewayws`) requires **independent of FDB**.

## Symptom
`./build.sh` fails in the gateway build stage:
```
# [pkg-config --cflags -- zlib]
Package zlib was not found in the pkg-config search path.
```

## Fix
Re-add zlib to both Dockerfiles — `zlib1g-dev` in the build stage (provides `zlib.pc`), `zlib1g` in the runtime stage (shared lib for the dynamically-linked binary). FoundationDB stays removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)