### PR TITLE
fix(docker): restore ca-certificates after FDB removal

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -13,7 +13,10 @@ ENV GO111MODULE=on
 RUN cd /go/src/github.com/tatsuworks/gateway/cmd/gateway && go build -o /go/gateway .
 
 FROM ubuntu:24.04
-RUN apt update && apt install -y adduser zlib1g
+# ca-certificates: ubuntu base ships no CA bundle; the gateway needs it to
+# verify Discord's TLS cert. Previously pulled in transitively by `wget` on
+# the (removed) FoundationDB install line. zlib1g: shared lib for czlib.
+RUN apt update && apt install -y adduser zlib1g ca-certificates
 
 COPY --from=0 /go/gateway /
 COPY entrypoint-gateway.sh /

--- a/Dockerfile.state
+++ b/Dockerfile.state
@@ -13,7 +13,10 @@ ENV GO111MODULE=on
 RUN cd /go/src/github.com/tatsuworks/gateway/cmd/state && go build -o /go/state .
 
 FROM ubuntu:24.04
-RUN apt update && apt install -y adduser zlib1g
+# ca-certificates: ubuntu base ships no CA bundle. Restores parity with the
+# pre-FDB-removal image (was pulled in transitively by `wget`). zlib1g: shared
+# lib for czlib.
+RUN apt update && apt install -y adduser zlib1g ca-certificates
 
 COPY --from=0 /go/state /
 COPY entrypoint-state.sh /


### PR DESCRIPTION
## What
Follow-up to #77. #76 (FoundationDB removal) deleted the apt line that installed `wget`; `wget` pulled in **`ca-certificates`** transitively. `ubuntu:24.04` ships no CA bundle, so the gateway runtime image lost it.

## Symptom (observed on staging, gateway:92b1bcd-release)
Pod boots fine (Postgres-only, 0 restarts) but the shard reconnect-loops forever:
```
failed to WebSocket dial ... https://gateway-us-east1-d.discord.gg ...:
tls: failed to verify certificate: x509: certificate signed by unknown authority
```
Confirmed `/etc/ssl/certs/ca-certificates.crt` absent and `ca-certificates` not installed in the pod.

## Fix
Add `ca-certificates` to the runtime stage of `Dockerfile.gateway` and `Dockerfile.state`, restoring parity with the pre-FDB-removal image. `wget` itself is not needed at runtime (entrypoints only `exec` the binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)