### PR TITLE
fix(gatewayws): abort channel sends on ctx cancel; cancel connection when writer dies

### DIFF
--- a/internal/gatewayws/heartbeat_deadlock_test.go
+++ b/internal/gatewayws/heartbeat_deadlock_test.go
@@ -1,0 +1,139 @@
+package gatewayws
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cdr.dev/slog/sloggers/slogtest"
+	"golang.org/x/time/rate"
+)
+
+// When the writer goroutine exits (e.g. a broken socket fails writeOp), it must
+// cancel the connection context. Otherwise the read loop and sendHeartbeats can
+// block forever on the unbuffered prioch send in writeHeartbeat — nothing drains
+// prioch and nothing tears the connection down. Observed in production as shards
+// frozen at "handle internal event " (empty type = the heartbeat op) with a
+// stuck seq, unrecoverable even by ForceIdentify.
+func TestWriterCancelsConnectionWhenItExits(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:    ctx,
+		cancel: cancel,
+		log:    slogtest.Make(t, nil),
+		// burst 0 => rl.Wait(ctx) returns an error immediately, driving writer()
+		// down its abnormal-exit path without needing a real websocket.
+		rl:     rate.NewLimiter(rate.Every(time.Hour), 0),
+		wch:    make(chan *Op, 1),
+		prioch: make(chan *Op, 1),
+		authed: true,
+	}
+	s.prioch <- &Op{Op: 1} // give writer a message so it advances to rl.Wait and exits
+
+	done := make(chan struct{})
+	go func() { s.writer(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer did not return")
+	}
+
+	select {
+	case <-s.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("writer exited without cancelling the connection context; the read loop can deadlock on prioch")
+	}
+}
+
+// writeHeartbeat must not block forever when no writer is draining prioch. Once
+// the connection context is cancelled (writer death, ForceIdentify, or the
+// heartbeat watchdog) the send must abort so the read loop can unwind and
+// reconnect.
+func TestWriteHeartbeatUnblocksWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:    ctx,
+		cancel: cancel,
+		log:    slogtest.Make(t, nil),
+		prioch: make(chan *Op), // unbuffered, no receiver: a bare send would wedge
+	}
+	cancel() // connection is being torn down
+
+	done := make(chan struct{})
+	go func() {
+		s.writeHeartbeat()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeHeartbeat blocked on prioch after context cancel (deadlock)")
+	}
+}
+
+// assertUnblocksOnCancel runs a Session send method with no receiver draining
+// prioch/wch and a cancelled connection context, and fails if it doesn't return
+// promptly. A bare channel send would deadlock here exactly as writeHeartbeat
+// did; every gateway-initiated send must abort on ctx.Done instead.
+func assertUnblocksOnCancel(t *testing.T, name string, run func(*Session)) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:    ctx,
+		cancel: cancel,
+		log:    slogtest.Make(t, nil),
+		prioch: make(chan *Op),
+		wch:    make(chan *Op),
+	}
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		run(s)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s blocked on channel send after context cancel (deadlock)", name)
+	}
+}
+
+func TestWriteIdentifyUnblocksOnCancel(t *testing.T) {
+	assertUnblocksOnCancel(t, "writeIdentify", (*Session).writeIdentify)
+}
+
+func TestWriteResumeUnblocksOnCancel(t *testing.T) {
+	assertUnblocksOnCancel(t, "writeResume", (*Session).writeResume)
+}
+
+func TestRequestGuildMembersUnblocksOnCancel(t *testing.T) {
+	assertUnblocksOnCancel(t, "RequestGuildMembers", func(s *Session) { s.RequestGuildMembers(123) })
+}
+
+// The fix must not break the happy path: with a receiver draining prioch and a
+// live context, writeHeartbeat still delivers the heartbeat op.
+func TestWriteHeartbeatDeliversWhenDrained(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &Session{
+		ctx:    ctx,
+		cancel: cancel,
+		log:    slogtest.Make(t, nil),
+		prioch: make(chan *Op),
+	}
+
+	go s.writeHeartbeat()
+
+	select {
+	case op := <-s.prioch:
+		if op.Op != 1 {
+			t.Fatalf("heartbeat op = %d, want 1", op.Op)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeHeartbeat did not deliver to a draining receiver")
+	}
+}

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -23,6 +23,11 @@ func (s *Session) writer() {
 		isPrio bool
 	)
 
+	// A dead writer means the connection is unusable. Cancel it on exit so the
+	// read loop and sendHeartbeats can't block forever on the unbuffered
+	// prioch/wch sends (nothing else drains them once writer is gone).
+	defer s.Cancel()
+
 	for {
 		var msg *Op
 		select {
@@ -100,7 +105,10 @@ type updatePresence struct {
 }
 
 func (s *Session) writeIdentify() {
-	s.prioch <- &Op{
+	select {
+	case <-s.ctx.Done():
+		return
+	case s.prioch <- &Op{
 		Op: 2,
 		D: Identify{
 			Token: s.token,
@@ -123,6 +131,7 @@ func (s *Session) writeIdentify() {
 				Status: "online",
 			},
 		},
+	}:
 	}
 }
 
@@ -133,20 +142,28 @@ type Resume struct {
 }
 
 func (s *Session) writeResume() {
-	s.prioch <- &Op{
+	select {
+	case <-s.ctx.Done():
+	case s.prioch <- &Op{
 		Op: 6,
 		D: Resume{
 			Token:     s.token,
 			SessionID: s.sessID,
 			Sequence:  atomic.LoadInt64(&s.seq),
 		},
+	}:
 	}
 }
 
 func (s *Session) writeHeartbeat() {
-	s.prioch <- &Op{
+	// Abort if the connection is being torn down. prioch is unbuffered, so a bare
+	// send wedges the read loop forever once writer() has exited.
+	select {
+	case s.prioch <- &Op{
 		Op: 1,
 		D:  atomic.LoadInt64(&s.seq),
+	}:
+	case <-s.ctx.Done():
 	}
 }
 
@@ -250,5 +267,8 @@ func (s *Session) RequestGuildMembers(guildID int64) {
 	}
 
 	s.log.Info(s.ctx, "sending members request", slog.F("guild", guildID))
-	s.wch <- op
+	select {
+	case s.wch <- op:
+	case <-s.ctx.Done():
+	}
 }


### PR DESCRIPTION
## Problem

A force-identify or a broken socket could **permanently wedge a shard**. Observed in production during a mass re-identify as shards frozen at status `handle internal event ` (empty event type = the heartbeat op) with a stuck `seq`, **unrecoverable even by `ForceIdentify`**.

### Root cause

- `writeHeartbeat` did a bare blocking send on the **unbuffered** `prioch`.
- When the `writer()` goroutine exited (writeOp error / ctx cancel), nothing drained `prioch`, so the read loop blocked there forever.
- `sendHeartbeats` — the watchdog that would cancel the connection on no-ack — blocked on the *same* send, so it never fired.
- `ForceIdentify` only sets a flag and cancels `ctx`; a bare channel send doesn't observe cancellation, so the shard could not recover.

## Fix (two parts)

1. **`writer()` cancels the connection on exit** (`defer s.Cancel()`) — a dead writer tears the connection down instead of stranding the read loop.
2. **All gateway-initiated sends select on `s.ctx.Done()`** (`writeHeartbeat`, `writeIdentify`, `writeResume`, `RequestGuildMembers`) so they abort on teardown instead of blocking on a full/undrained channel.

Together the deadlock self-heals (writer death → ctx cancel → sends abort → read loop unwinds → reconnect), and `ForceIdentify` can again recover a wedged shard.

## Tests

Adds `internal/gatewayws/heartbeat_deadlock_test.go` — each send aborts on ctx-cancel, writer-cancels-on-exit, and the happy-path delivery is preserved. Full package green under `-race`; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)