### PR TITLE
refactor(gatewayws): split Session into durable Session + per-Open conn

### DIFF
--- a/agent-progress.md
+++ b/agent-progress.md
@@ -137,3 +137,16 @@
   - `env GOCACHE=/tmp/go-build-cache go test ./discord/... ./internal/gatewayws/...` -> PASS.
   - `env GOCACHE=/tmp/go-build-cache go build ./...` -> exit 0; same non-fatal read-only module stat-cache warning.
 - Known risk or unresolved issue: none for this cleanup. The branch remains locally ahead/behind its upstream because the upstream branch has the same subject at a different commit SHA; no push was performed.
+
+### Session 006 — conn-lifecycle refactor (Session → Session + per-Open conn) (2026-06-23)
+
+- Goal: retire the bug class behind the WS-deadlock fixes by restructuring, rather than patching, `internal/gatewayws`. Split the reused-across-reconnects `Session` god-object into a durable `Session` (identity, shared deps, resume tuple) and a fresh-per-`Open()` `conn` (ctx/cancel, wch/prioch, websocket, buffers, heartbeat timing). Branch `refactor/conn-lifecycle` off `fix/ws-send-deadlock-on-writer-exit` HEAD (`778d772`, which includes the bounded-write + writeOp flush-error check).
+- Plan: `docs/superpowers/plans/2026-06-23-conn-lifecycle-refactor.md` (written, codex-reviewed; all 8 must-fix items folded in before execution).
+- Completed (commits `93e1585`, `d0a090d`, `1bea7f8` + plan `89731fb`):
+  - New `conn` type owns per-connection state; `Session` keeps a `cur atomic.Pointer[conn]` that management RPCs (`Cancel`/`ForceIdentify`/`RequestGuildMembers`/`Status`/`LongLastAck`) route through.
+  - Deleted the three reconnect-reset hacks a fresh conn makes unnecessary: `resetHeartbeat`, the identify-path `wch`/`prioch` swap, and the INVALID_SESSION `s.wch = make(...)` rebuild.
+  - Preserved behavior deliberately: `guilds`/`backfilled` stay on `Session` (read-loop single-owner, survive RESUME so the backfill-skip optimization holds); `last` atomic on `Session`; `run(parent)` keeps the two-context split so `state.HandleEvent`/`maybeRequestGuildMembers` still run under the parent ctx (in-flight DB work survives a disconnect); `Open` cancels the connection before clearing `cur`.
+  - Closed the pre-existing `lastAck`/`curState` data race: `lastHB`/`lastAck`/`ready`/`curState` are now behind a `conn.mu` (setState/markHB/markAck/markReady/snapshot); `authed` is `atomic.Bool`.
+  - Two blessed, documented behavior changes: `RequestGuildMembers` is dropped+logged when no connection is active; `Status`/`LongLastAck` report `<disconnected>`/`true` on nil `cur`.
+- Verification: `go build ./...` clean; `go vet ./...` clean; `go test -race ./internal/gatewayws/ ./internal/manager/ ./gatewaypb/` PASS (19 gatewayws tests incl. new channel-independence, nil-cur, and Status-race tests). External API signatures (`go doc Session`) unchanged. Greps confirm no reset-hacks and no stale `s.<conn-field>` access remain.
+- Known risk / next step: not deployed (per AGENTS.md, shipping is a separate helm staging-deploy). Branch not pushed (awaiting maintainer go-ahead). NOTE: the agent-progress Session 005 entry describes the deadlock branch with `defer w.Close()` and no flush-error surfacing, but this refactor was based on `778d772` which *does* surface the writeOp flush error — the two narratives diverge; reconcile when the deadlock PR and this refactor are sequenced for merge.

--- a/docs/superpowers/plans/2026-06-23-conn-lifecycle-refactor.md
+++ b/docs/superpowers/plans/2026-06-23-conn-lifecycle-refactor.md
@@ -1,0 +1,693 @@
+# Connection-Lifecycle Refactor (`Session` → `Session` + `conn`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the reused-across-reconnects `gatewayws.Session` god-object into a durable `Session` (identity + deps + resume tuple) and a fresh-per-`Open()` `conn` (connection-scoped channels, sockets, goroutines, timing), so the bug class we keep patching (captured-channel orphaning, heartbeat reset loops, `lastHB`/`lastAck` data races) becomes structurally impossible.
+
+**Architecture:** Today one mutable `Session` is reused for every reconnect; `Open()` manually resets connection state (`resetHeartbeat`, `wch`/`prioch` swaps, `s.wch = make(...)` on INVALID_SESSION) and four goroutines (`writer`, `sendHeartbeats`, read loop, `logTotalEvents`) mutate shared struct fields with no synchronization. After this refactor, each `Open()` constructs a brand-new `conn` that *owns* its ctx/cancel, channels, websocket, buffers and timing state; the `Session` keeps only durable identity, shared dependencies, and the resume tuple, plus an `atomic.Pointer[conn]` to the current connection so management RPCs (`Cancel`/`ForceIdentify`/`RequestGuildMembers`/`Status`/`LongLastAck`) route to it. A connection cannot inherit stale channels or timestamps because they did not exist a moment earlier.
+
+**Tech Stack:** Go 1.25, `nhooyr.io/websocket`, `golang.org/x/time/rate`, `cdr.dev/slog`, etcd `concurrency`, `czlib`. Tests use `slogtest` and the standard `testing` package; the race detector is the primary regression gate.
+
+## Global Constraints
+
+- **Behavior-preserving.** This is a pure restructuring. No protocol behavior, timing, log message, or persisted-state change is in scope except the synchronization fixes called out in Task 5. Discord-facing behavior must be identical.
+- **External API frozen.** These exported symbols and signatures must not change — they are consumed by `internal/manager`: `gatewayws.NewSession(*SessionConfig) (*Session, error)`, `(*Session).Open(ctx context.Context, token string) error`, `(*Session).ForceIdentify()`, `(*Session).Cancel()`, `(*Session).RequestGuildMembers(guildID int64)`, `(*Session).Status() string`, `(*Session).LongLastAck(threshold time.Duration) bool`. Also frozen: `Intents`, `SessionConfig`, the `Intent*` consts, `LargeThreshold`.
+- **Green gate (run from `repos/gateway`, every commit):**
+  ```bash
+  GOCACHE=/tmp/go-build go build ./... \
+    && GOCACHE=/tmp/go-build go vet ./internal/gatewayws/ ./internal/manager/ \
+    && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/
+  ```
+- **Go version floor:** `go 1.25` (per `go.mod`) — `atomic.Pointer[T]` and `atomic.Bool` are available; use them, not `unsafe`/`atomic.Value`.
+- **Resume tuple stays single-owner.** `seq` (atomic int64), `sessID`, `resumeURL`, `last`, `forceIdentify` remain on `Session`. Mutation discipline: `seq`/`forceIdentify`/**`last`** via `sync/atomic`; `sessID`/`resumeURL` mutated only on the read-loop / `Open` goroutine. Do not move these onto `conn`. (`last` MUST become atomic — see Design Decision 8; it is written from the `logTotalEvents` goroutine today, so leaving it a bare field is a race.)
+
+---
+
+## Design Decisions (read before starting)
+
+These were chosen deliberately; flag the maintainer if you disagree before coding.
+
+1. **`conn` holds a back-reference `s *Session`** for durable deps (logger, encoder, DB, redis, etcd, rate limiter, buffer pool) and the resume tuple. Connection methods read deps via `c.s.X`. This avoids copying deps and keeps one source of truth.
+2. **`rl *rate.Limiter` stays on `Session` (shared across reconnects).** Today the limiter persists between connections; making it per-`conn` would reset the send budget on every reconnect — a behavior change. Keep it on `Session`; `writer` calls `c.s.rl.Wait(c.ctx)`.
+3. **`bufferPool` stays on `Session`; the in-flight `buf` moves to `conn`.** The pool is a shared dependency; the borrowed buffer is connection-scoped.
+4. **Timing/state fields (`lastHB`, `lastAck`, `ready`, `curState`) move to `conn` and are guarded by a `conn.mu sync.Mutex`** with `setState`/`snapshot` accessors. `authed` moves to `conn` as an `atomic.Bool` (it is read on the hot writer path). This subsumes the pre-existing `lastAck`/`curState` data races (review finding #3) — but that hardening is isolated to Task 5 so the receiver migration (Task 2–4) stays mechanical.
+5. **`Open()` becomes a thin wrapper**: build ctx, build `conn`, publish it to `s.cur`, run, clear `s.cur` on return. The former `Open()` body becomes `(*conn).run(token string) error`.
+6. **`resetHeartbeat` is deleted** (a fresh `conn` has zero-valued `lastHB`/`lastAck`), and the INVALID_SESSION `s.wch = make(chan *Op, 2000)` line and the identify-path channel-swap block are deleted — all three are reconnect-reset hacks that a fresh-per-connection object makes unnecessary.
+7. **Management routing tolerates a nil current connection** (a `Cancel`/`Status` can land before the first `Open` or between reconnects). Routing is via `s.cur.Load()` with a nil check.
+8. **`last` stays on `Session` as an atomic int64** (codex review #1). It is the event-rate baseline read AND written by the `logTotalEvents` goroutine (`log.go:30`/`log.go:43`) and reset by `Open` on identify (`ws.go:316`). Today it is an unsynchronized bare field — a latent race. Access it via `atomic.LoadInt64`/`atomic.StoreInt64` everywhere. Keeping it on `Session` (not `conn`) preserves the current resume-carryover: on RESUME the baseline is *not* reset, so the first post-resume "event report" stays accurate.
+9. **`guilds` and `backfilled` stay on `Session`, NOT `conn`** (codex review #2). They are mutated and read only on the read-loop goroutine (`READY` handler repopulates them; `GUILD_CREATE`/`isBackfilled` reads them) — single-owner, race-free. Critically, today both **survive a RESUME** (the `RESUMED` handler does not touch them), so the backfill-skip optimization (the 2026-06-18 RGM-skip feature) keeps working across resumes. Moving them to a fresh `conn` would empty them on every resume and re-trigger RGM/reconcile for already-backfilled guilds — a reconnect-storm regression. They are NOT in the Task 5 mutex block (single-owner needs no lock).
+10. **`run()` takes the parent context; the two-context split is preserved** (codex review #4). Today `Open` derives a *connection* context (`s.ctx`) for reads/writes/heartbeats/redis, but passes the *parent* (manager) context into `state.HandleEvent` (`ws.go:354`) and `maybeRequestGuildMembers` (`ws.go:367`) so in-flight DB work is NOT aborted by a disconnect. `(*conn).run(parent context.Context)` keeps `c.ctx` for connection-scoped work and threads `parent` into exactly those two calls. Do not switch them to `c.ctx`.
+11. **Two accepted, documented behavior changes** (codex review #5/#6 — blessed, not silent): (a) `RequestGuildMembers` via gRPC is *dropped with a log line* when there is no active connection, instead of best-effort buffering on a durable `wch`. It is a management RPC, the socket is down so it cannot be honored promptly anyway, and today's "durability" only held on the resume path — the very identify-path channel swap we are deleting already discarded it. (b) `Status()` returns `"<disconnected>"` and `LongLastAck()` returns `true` when `cur == nil` (between reconnects), rather than echoing the previous connection's stale `curState`/`lastAck`. This is strictly more informative for health monitoring; `LongLastAck`→`true` matches today's "stale ack ⇒ reported unhealthy" outcome.
+12. **Concurrent `Session.Open` is unsupported** (codex optional). The manager runs one serial `Open` loop per shard (`manager.go:182-198`), so this holds in production. We rely on it: a stale `Open`'s `defer s.cur.Store(nil)` could otherwise clear a newer conn. Documented as an invariant; not guarded.
+
+### Field partition
+
+| Field | Destination | Notes |
+|---|---|---|
+| `name`, `log`, `token`, `intents`, `shardID`, `shardCount`, `hasGuildMembersIntent` | `Session` | immutable identity |
+| `wg`, `bufferPool`, `enc`, `etcd`, `state`, `stateDB`, `rc`, `whitelistedEvents`, `rl` | `Session` | shared deps |
+| `seq`, `sessID`, `resumeURL`, `forceIdentify`, `lastIdentify` | `Session` | resume tuple (single-owner) |
+| `last` | `Session` (**atomic int64**) | event-rate baseline; written by `logTotalEvents` goroutine → must be atomic (Decision 8) |
+| `guilds`, `backfilled` | `Session` | read-loop single-owner; **survive RESUME** — keeping them here preserves backfill-skip (Decision 9) |
+| `cur atomic.Pointer[conn]` | `Session` | **new** — current connection |
+| `ctx`, `cancel` | `conn` | per-connection lifetime |
+| `wsConn`, `zr`, `interval`, `trace` | `conn` | per-connection transport |
+| `wch`, `prioch` | `conn` | **the bug source** — per-connection |
+| `buf` | `conn` | borrowed per read |
+| `etcdSess`, `identifyMu` | `conn` | created per `Open` in `initEtcd` |
+| `authed` | `conn` (`atomic.Bool`) | hot-path read in `writer` |
+| `lastHB`, `lastAck`, `ready`, `curState` | `conn` (under `conn.mu`) | Task 5 hardening |
+
+### Method-receiver migration map
+
+All of these change receiver from `(s *Session)` to `(c *conn)` and have their bodies rewritten so `s.X` becomes `c.X` (connection field), `c.s.X` (durable dep / resume tuple), or `c.s.method()` (durable method). Durable methods that touch only `Session` fields stay on `Session`.
+
+| Stays on `Session` | Moves to `conn` |
+|---|---|
+| `Status`, `LongLastAck` (route via `s.cur`) | `writer`, `writeOp`, `writeIdentify`, `writeResume`, `writeHeartbeat`, `heartbeatStale`, `sendHeartbeats`, `requestGuildMembers`, `rotateStatuses` |
+| `Cancel`, `ForceIdentify` (route via `s.cur`) | `readMessage`, `readHello`, `readAndDecodeEvent`, `cleanupBuffer` |
+| `RequestGuildMembers` (route via `s.cur`) | `handleInternalEvent`, `pushEventToRedis`, `maybeRequestGuildMembers`, `isBackfilled` |
+| `NewSession`, `shouldResume`, `shouldProcessMembers`, `calcIdentifyWait` | `GatewayURL`, `initEtcd`, `acquireIdentifyLock`, `releaseIdentifyLock`, `logTotalEvents` |
+| `applyForceIdentify`, `persistShardInfo`, `persistStatus`, `loadSeq`, `loadSessID`, `loadResumeURL` | `Open`-body → `(*conn).run` |
+| `resetHeartbeat` | **DELETED** |
+
+Notes:
+- `shouldProcessMembers`/`calcIdentifyWait` read only intents/`shardID` → stay on `Session`; conn calls `c.s.shouldProcessMembers()`.
+- `maybeRequestGuildMembers`/`isBackfilled` move to `conn` but read `c.s.backfilled` (stays on Session per Decision 9) and `c.s.stateDB`.
+- `handleInternalEvent` (conn method) repopulates `c.s.guilds`/`c.s.backfilled` in the READY branch and reads `c.s.backfilled` discipline is unchanged (read-loop single-owner).
+- `persistShardInfo`/`applyForceIdentify` mutate only resume-tuple fields → stay on `Session`, called via `c.s.`. Their slog calls currently use `s.ctx`; since `s.ctx` is removed, switch those log calls to `context.Background()` (they already use `context.Background()` for their DB calls). Same for `loadSeq`/`loadSessID`/`loadResumeURL` (Decision/codex #3).
+- `persistStatus` reads `curState` which now lives on `conn`. Change its signature to `func (s *Session) persistStatus(state string)`; the only caller is `logTotalEvents`, which passes `c.state()` (the mutex-guarded read added in Task 5; pre-Task-5 it passes `c.curState`). Its slog call also moves to `context.Background()`.
+- `GatewayURL` reads `c.s.resumeURL`/`c.s.sessID` (Session) and `c.s.enc` → on `conn`.
+
+---
+
+## Task 1: Establish the green baseline and lock the invariants in tests
+
+**Files:**
+- Test: `internal/gatewayws/conn_lifecycle_test.go` (Create)
+
+**Interfaces:**
+- Produces: nothing structural — this task records the starting state and writes the acceptance tests the refactor must satisfy. The tests reference symbols that exist today (`Session`, channels) and are rewritten to `conn` in Task 4 once the type exists; for now they pin *current* behavior so we can prove the refactor preserved it.
+
+- [ ] **Step 1: Run the existing suite under the race detector and record it is green**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/ -v 2>&1 | tail -30
+```
+Expected: `ok  github.com/tatsuworks/gateway/internal/gatewayws` and `ok  .../internal/manager` (or `no test files` for manager). If anything fails, STOP — fix the baseline before refactoring (per repo AGENTS.md: never stack work on a broken baseline).
+
+- [ ] **Step 2: Write the channel-independence acceptance test (currently un-writable against `Session`; defer the body)**
+
+Add a placeholder test that documents the invariant and skips, so it is tracked but does not block the baseline:
+
+```go
+package gatewayws
+
+import "testing"
+
+// After the conn refactor, two sequential connections must not share send
+// channels: a fresh conn allocates its own wch/prioch, so a producer for
+// connection B can never reach connection A's writer (the captured-locals
+// orphaning bug). Re-enabled with a real body in Task 4 once conn exists.
+func TestSequentialConnsDoNotShareChannels(t *testing.T) {
+	t.Skip("enabled in Task 4 after conn type exists")
+}
+```
+
+- [ ] **Step 3: Verify the skipped test compiles and the suite is still green**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ -run TestSequentialConnsDoNotShareChannels -v
+```
+Expected: `--- SKIP: TestSequentialConnsDoNotShareChannels`, package `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/gatewayws/conn_lifecycle_test.go
+git commit -m "test(gatewayws): record green baseline + pin conn-refactor invariants"
+```
+
+---
+
+## Task 2: Introduce the `conn` type and migrate all connection-scoped methods to it
+
+This is the structural core. **It is a single Go type migration: the package will not compile partway through — that is expected. Do not run the green gate or commit until the final step.** Work in the field/method order below to minimize churn.
+
+**Files:**
+- Create: `internal/gatewayws/conn.go`
+- Modify: `internal/gatewayws/ws.go` (`Session` struct, `NewSession`, `Open`, `handleInternalEvent`, `pushEventToRedis`, `GatewayURL`, `initEtcd`, `acquireIdentifyLock`, `releaseIdentifyLock`, `readAndDecodeEvent`, `cleanupBuffer`, `Cancel`, `ForceIdentify`, `Status`, `LongLastAck`, delete `resetHeartbeat`)
+- Modify: `internal/gatewayws/write.go` (all `writer`/`write*`/`heartbeatStale`/`sendHeartbeats`/`requestGuildMembers`/`rotateStatuses`/`RequestGuildMembers` receivers)
+- Modify: `internal/gatewayws/read.go`, `internal/gatewayws/hello.go` (`readMessage`, `readHello` receivers)
+- Modify: `internal/gatewayws/backfill.go` (`maybeRequestGuildMembers`, `isBackfilled` receivers)
+- Modify: `internal/gatewayws/log.go` (`logTotalEvents` receiver)
+
+**Interfaces:**
+- Produces (new `conn.go`):
+  ```go
+  type conn struct {
+      s *Session
+
+      ctx    context.Context
+      cancel context.CancelFunc
+
+      wsConn *websocket.Conn
+      zr     io.ReadCloser
+
+      interval time.Duration
+      trace    string
+
+      wch    chan *Op
+      prioch chan *Op
+
+      buf *bytes.Buffer
+
+      etcdSess   *concurrency.Session
+      identifyMu *concurrency.Mutex
+
+      authed atomic.Bool
+
+      // Task 5 will guard these with mu; declared here so receivers compile now.
+      mu       sync.Mutex
+      lastHB   time.Time
+      lastAck  time.Time
+      ready    time.Time
+      curState string
+  }
+
+  func (s *Session) newConn(ctx context.Context, cancel context.CancelFunc) *conn
+  func (c *conn) run(token string) error          // former Open body
+  ```
+- Produces (on `Session`): `cur atomic.Pointer[conn]`; `Open`/`Cancel`/`ForceIdentify`/`Status`/`LongLastAck`/`RequestGuildMembers` route through `cur`.
+- Consumes: Task 1 baseline.
+
+- [ ] **Step 1: Create `conn.go` with the struct above and `newConn`**
+
+```go
+package gatewayws
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/etcd-io/etcd/clientv3/concurrency"
+	"nhooyr.io/websocket"
+)
+
+// conn is a single gateway connection. A fresh conn is built per Open and
+// discarded when that connection dies, so connection-scoped state (channels,
+// socket, heartbeat timing) can never leak across reconnects.
+type conn struct {
+	s *Session
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wsConn *websocket.Conn
+	zr     io.ReadCloser
+
+	interval time.Duration
+	trace    string
+
+	wch    chan *Op
+	prioch chan *Op
+
+	buf *bytes.Buffer
+
+	guilds     map[int64]struct{}
+	backfilled map[int64]struct{}
+
+	etcdSess   *concurrency.Session
+	identifyMu *concurrency.Mutex
+
+	authed atomic.Bool
+
+	mu       sync.Mutex
+	lastHB   time.Time
+	lastAck  time.Time
+	ready    time.Time
+	curState string
+}
+
+func (s *Session) newConn(ctx context.Context, cancel context.CancelFunc) *conn {
+	return &conn{
+		s:      s,
+		ctx:    ctx,
+		cancel: cancel,
+		wch:    make(chan *Op, 2000),
+		prioch: make(chan *Op),
+	}
+}
+```
+
+- [ ] **Step 2: Trim the `Session` struct in `ws.go`**
+
+Remove these fields from `Session`: `ctx`, `cancel`, `wsConn`, `zr`, `interval`, `trace`, `wch`, `prioch`, `lastHB`, `lastAck`, `ready`, `curState`, `buf`, `authed`, `etcdSess`, `identifyMu`. Add `cur atomic.Pointer[conn]`. **Keep** `guilds`, `backfilled` (Decision 9) and `last` (Decision 8) on `Session`. Keep everything else in the "Session" rows of the field-partition table. Drop the now-unused `bytes`/`io`/`websocket` imports from `ws.go` only if nothing else there uses them (the read/decode helpers move to conn, so re-check after Step 6).
+
+- [ ] **Step 3: In `NewSession`, drop the connection-field initializers**
+
+Remove `ctx: context.Background()`, `wch: make(...)`, `prioch: make(...)` from the `&Session{...}` literal (channels now belong to `conn`; `rl` stays). Everything else in `NewSession` (loadSessID/loadSeq/loadResumeURL, intent scan) is unchanged.
+
+- [ ] **Step 4: Convert `write.go` receivers to `(c *conn)`**
+
+For every method in the "Moves to conn" list that lives in `write.go` (`writer`, `writeOp`, `writeIdentify`, `writeResume`, `writeHeartbeat`, `heartbeatStale`, `sendHeartbeats`, `requestGuildMembers`, `rotateStatuses`), change `func (s *Session)` → `func (c *conn)` and rewrite field references by this rule:
+  - connection field (`ctx`, `wch`, `prioch`, `wsConn`, `interval`, `lastHB`, `lastAck`) → `c.X`
+  - durable dep / resume tuple (`rl`, `log`, `enc`, `seq`, `token`, `sessID`, `intents`, `shardID`, `shardCount`) → `c.s.X`
+  - `s.authed` → `c.authed.Load()` (writer) — the bare-bool read becomes the atomic load
+  - `s.cancel` inside `sendHeartbeats` → `c.cancel`
+  - `s.Cancel()` inside `writer`'s `defer` → `c.cancel()` (cancel *this* connection directly; no nil-guard needed — a conn always has a cancel)
+
+Delete the now-unused `resetHeartbeat` (it is in `write.go`).
+
+Convert the **internal** `requestGuildMembers(guild int64)` (the `default:`-drop variant) to `(c *conn)`. Leave the **exported** `RequestGuildMembers` migration for Step 7.
+
+- [ ] **Step 5: Convert `read.go`, `hello.go`, `backfill.go`, `log.go` receivers**
+
+Mechanically apply the same receiver swap and field rule to: `readMessage`, `readHello` (read `c.wsConn`, `c.zr`, `c.buf`, `c.s.bufferPool`, `c.s.enc`, sets `c.interval`/`c.trace`); `readAndDecodeEvent`, `cleanupBuffer` (move these two from `ws.go` to conn methods — they touch `buf`/`bufferPool`/`wsConn`; `cleanupBuffer` reads `c.buf`, `c.s.bufferPool`, `c.s.log`); `maybeRequestGuildMembers`, `isBackfilled` (read `c.s.backfilled` — stays on Session per Decision 9 — call `c.requestGuildMembers`, `c.s.stateDB`); `logTotalEvents` (reads `c.ctx`, `c.s.seq` atomic, `c.s.last` **via `atomic.LoadInt64`**, `len(c.wch)`, `c.s.state.WaitingQueries()`, `c.curState`, writes `c.s.last` **via `atomic.StoreInt64`**, calls `c.s.persistStatus(c.curState)` — see Step 8 note).
+
+- [ ] **Step 6: Convert the remaining `ws.go` connection methods to `(c *conn)`**
+
+`GatewayURL` (reads `c.s.enc`, `c.s.resumeURL`, `c.s.sessID`), `initEtcd` (reads `c.s.etcd`, `c.s.calcIdentifyWait`, `c.ctx`; sets `c.etcdSess`, `c.identifyMu`), `acquireIdentifyLock`/`releaseIdentifyLock` (read `c.identifyMu`, `c.ctx`, `c.s.log`), `handleInternalEvent` (reads/writes `c.s.seq` atomic, `c.s.sessID`, `c.s.resumeURL`, `c.s.guilds`, `c.s.backfilled` — both stay on Session per Decision 9 — `c.authed`, `c.lastAck`, `c.ready`, `c.identifyMu`, calls `c.s.persistShardInfo`, `c.releaseIdentifyLock`, `c.writeHeartbeat`, `c.s.calcIdentifyWait`, `c.s.stateDB`, `c.s.enc`). In the READY delayed-unlock goroutine, use a local `if err := c.releaseIdentifyLock(); err != nil { ... }` rather than assigning the outer `err` (codex optional cleanup; avoids a closure foot-gun), `pushEventToRedis` (reads `c.s.whitelistedEvents`, `c.s.rc`, `c.s.log`, `c.ctx`).
+
+In `handleInternalEvent` case 9 (INVALID_SESSION): **delete the `s.wch = make(chan *Op, 2000)` line** — the next `Open` builds a fresh conn with fresh channels. Keep the rest of case 9.
+
+- [ ] **Step 7: Rewrite `Open` as a wrapper + move its body into `(*conn).run`**
+
+Replace `Open` and add `run`:
+
+```go
+func (s *Session) Open(ctx context.Context, token string) error {
+	s.wg.Add(1)
+	defer s.wg.Done()
+
+	cctx, cancel := context.WithCancel(ctx)
+
+	c := s.newConn(cctx, cancel)
+	s.cur.Store(c)
+	// Cancel the connection's goroutines BEFORE retracting it from cur, so a
+	// concurrent Cancel/ForceIdentify never sees a nil cur while this
+	// connection's context is still live (codex review #7). Single combined
+	// defer guarantees the order regardless of LIFO.
+	defer func() {
+		cancel()
+		s.cur.Store(nil)
+	}()
+
+	return c.run(ctx) // pass the PARENT ctx; see two-context note below
+}
+```
+
+`(*conn).run(parent context.Context) error` is the former `Open` body with these edits:
+  - signature is `func (c *conn) run(parent context.Context) error`. `Open`'s own `token` parameter stays unused exactly as today (the body reads `c.s.token`); do not thread it into `run`. Confirm by grep that `Open`'s `token` param is unused.
+  - drop `s.wg.Add/Done` and the ctx creation (now in `Open`);
+  - drop `defer func(){ s.authed = false }()` → `defer c.authed.Store(false)`;
+  - drop `s.resetHeartbeat()` (fresh conn);
+  - drop the identify-path channel-swap block entirely (the `if !s.shouldResume() && len(...)>0 { ... }`) — fresh conn already has empty channels;
+  - `s.last = 0` (the identify-path reset) → `atomic.StoreInt64(&c.s.last, 0)` (Decision 8);
+  - `s.applyForceIdentify()` → `c.s.applyForceIdentify()`; `s.shouldResume()` → `c.s.shouldResume()`; `s.initEtcd()`/`acquireIdentifyLock()` → `c.initEtcd()`/`c.acquireIdentifyLock()`;
+  - `go s.writer()` → `go c.writer()`, etc. for `sendHeartbeats`, `logTotalEvents`;
+  - `s.curState = "..."` → `c.curState = "..."` (Task 5 swaps these for `c.setState(...)`);
+  - **Two-context rule (codex review #4 — behavior-critical):** in the read loop, connection-scoped work uses `c.ctx` (`readAndDecodeEvent`, `writeHeartbeat`, `pushEventToRedis`, all already routed via `c.ctx`), but the two calls that today receive the *parent* ctx keep receiving `parent`: `c.s.state.HandleEvent(parent, ev)` and `c.maybeRequestGuildMembers(parent, evtPayload)`. Do NOT switch these to `c.ctx` — that would abort in-flight DB writes on disconnect. `maybeRequestGuildMembers`'s `ctx` parameter therefore receives `parent`.
+  - remaining read loop `s.X` → `c.X` / `c.s.X` per the rule;
+  - `defer s.persistShardInfo()` → `defer c.s.persistShardInfo()`.
+
+- [ ] **Step 8: Resolve `persistStatus`/`persistShardInfo` curState access**
+
+`persistStatus` (in `persistence.go`) reads `s.curState`, which now lives on `conn`. Keep `persistStatus` on `Session` but give it the state as an argument: change to `func (s *Session) persistStatus(state string)` and pass it in — `logTotalEvents` calls `c.s.persistStatus(c.curState)` (Task 5: `c.state()`). `Open`/`run` have no direct `persistStatus` call (only `persistShardInfo`). Verify with grep that `persistStatus` has exactly the call site(s) in `log.go`.
+
+**Compile fix (codex review #3) — `s.ctx` is gone, so the Session-level persistence/load/force methods can no longer log with it.** In `persistShardInfo`, `persistStatus`, `loadSeq`, `loadSessID`, `loadResumeURL` (all `persistence.go`) and `applyForceIdentify` (`ws.go`), change every `s.log.*(s.ctx, ...)` to `s.log.*(context.Background(), ...)`. This is behavior-equivalent: those methods already pass `context.Background()` to their DB calls, and at `NewSession` time `s.ctx` was `context.Background()` anyway. These stay `(*Session)` methods (they touch only resume-tuple fields), called via `c.s.`.
+
+- [ ] **Step 9: Rewire the management methods on `Session`**
+
+```go
+func (s *Session) Cancel() {
+	if c := s.cur.Load(); c != nil {
+		c.cancel()
+	}
+}
+
+func (s *Session) ForceIdentify() {
+	atomic.StoreInt32(&s.forceIdentify, 1)
+	s.Cancel()
+}
+
+func (s *Session) RequestGuildMembers(guildID int64) {
+	c := s.cur.Load()
+	if c == nil {
+		s.log.Info(context.Background(), "drop members request: no active connection", slog.F("guild", guildID))
+		return
+	}
+	c.requestGuildMembersExternal(guildID)
+}
+```
+
+Move the exported-`RequestGuildMembers` *body* (the `select { case s.wch <- op: case <-s.ctx.Done(): }` version with the info log) onto `conn` as `requestGuildMembersExternal(guildID int64)`, reading `c.wch`/`c.ctx`/`c.s.log`. (Keep `Status`/`LongLastAck` for Step 10.)
+
+- [ ] **Step 10: Rewire `Status` / `LongLastAck` through `s.cur`**
+
+```go
+func (s *Session) Status() string {
+	c := s.cur.Load()
+	if c == nil {
+		return fmt.Sprintf("%v: <disconnected>", s.shardID)
+	}
+	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, c.curState, c.lastAck.Format(time.RFC3339))
+}
+
+func (s *Session) LongLastAck(threshold time.Duration) bool {
+	c := s.cur.Load()
+	if c == nil {
+		// no active connection => definitionally not acking
+		return true
+	}
+	cutoff := time.Now().Add(-threshold)
+	return c.lastAck.Before(cutoff) && c.ready.Before(cutoff)
+}
+```
+(Task 5 replaces the raw `c.curState`/`c.lastAck`/`c.ready` reads with a mutex-guarded `c.snapshot()`.)
+
+- [ ] **Step 11: Build, vet, and run the race suite (first compile point)**
+
+Run the full green gate:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go build ./... \
+  && GOCACHE=/tmp/go-build go vet ./internal/gatewayws/ ./internal/manager/ \
+  && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/ 2>&1 | tail -30
+```
+Expected: builds clean, vet clean, and tests **fail to compile** only in the test files that construct `Session{ctx:..., wch:...}` literals (force_identify_test.go, heartbeat_deadlock_test.go, conn_lifecycle_test.go). Production code must build. If production fails to build, fix before moving on. Do **not** commit yet — test migration is Task 4 and the commit is shared.
+
+> If you prefer a green commit here, temporarily build-tag or `t.Skip` the broken test files, commit production, then un-skip in Task 4. Otherwise carry the uncommitted change into Task 4 and commit once.
+
+---
+
+## Task 3: Migrate the test files to the `conn` type
+
+**Files:**
+- Modify: `internal/gatewayws/heartbeat_deadlock_test.go`
+- Modify: `internal/gatewayws/force_identify_test.go`
+- Modify: `internal/gatewayws/conn_lifecycle_test.go`
+
+**Interfaces:**
+- Consumes: the `conn` type and methods from Task 2.
+- Produces: a compiling, green `-race` suite proving behavior preserved.
+
+- [ ] **Step 1: Port `heartbeat_deadlock_test.go` to build `conn` literals**
+
+Every `s := &Session{ctx, cancel, log, rl, wch, prioch, prioch, authed, ...}` becomes a `conn` literal. The methods under test (`writer`, `writeHeartbeat`, `writeIdentify`, `writeResume`, `heartbeatStale`, `RequestGuildMembers`) are now conn methods, except `RequestGuildMembers` which is still a `Session` method that routes to the conn. Rewrite, e.g.:
+
+```go
+func TestWriterCancelsConnectionWhenItExits(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{log: slogtest.Make(t, nil), rl: rate.NewLimiter(rate.Every(time.Hour), 0)}
+	c := &conn{
+		s:      s,
+		ctx:    ctx,
+		cancel: cancel,
+		wch:    make(chan *Op, 1),
+		prioch: make(chan *Op, 1),
+	}
+	c.authed.Store(true)
+	c.prioch <- &Op{Op: 1}
+
+	done := make(chan struct{})
+	go func() { c.writer(); close(done) }()
+	// ...assert <-done, then <-c.ctx.Done() as before, replacing s.ctx with c.ctx...
+}
+```
+Apply the analogous change to `TestWriteHeartbeatUnblocksWhenContextCancelled`, `assertUnblocksOnCancel` (build a `conn`, call `run func(*conn)`), `TestWriteIdentifyUnblocksOnCancel`/`TestWriteResumeUnblocksOnCancel` (`(*conn).writeIdentify`/`(*conn).writeResume`), and `TestRequestGuildMembersUnblocksOnCancel`. For the RGM test, because `RequestGuildMembers` now routes through `s.cur`, set it up:
+```go
+s := &Session{log: slogtest.Make(t, nil)}
+c := &conn{s: s, ctx: ctx, cancel: cancel, wch: make(chan *Op), prioch: make(chan *Op)}
+s.cur.Store(c)
+cancel()
+// assert s.RequestGuildMembers(123) returns promptly
+```
+`TestHeartbeatStale` uses `&Session{lastHB, lastAck, interval}` → `&conn{lastHB:..., lastAck:..., interval:...}` and `s.heartbeatStale(...)` → `c.heartbeatStale(...)`. `TestWriteHeartbeatDeliversWhenDrained` (`heartbeat_deadlock_test.go:172`) → build a `conn` and call `c.writeHeartbeat()` against `c.prioch`.
+
+**`TestResetHeartbeatPreventsStaleCancelAfterReconnect` (`heartbeat_deadlock_test.go:152`) calls the deleted `resetHeartbeat` (codex review #8).** Rewrite it to assert the invariant `resetHeartbeat` used to guarantee, now provided structurally by `newConn`:
+
+```go
+func TestFreshConnHasZeroHeartbeatState(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := s.newConn(ctx, cancel)
+	c.interval = 40 * time.Second
+	if !c.lastHB.IsZero() || !c.lastAck.IsZero() {
+		t.Fatalf("fresh conn carried heartbeat state: lastHB=%v lastAck=%v", c.lastHB, c.lastAck)
+	}
+	if c.heartbeatStale(time.Now()) {
+		t.Fatal("heartbeatStale fired on a fresh connection; would cause a reconnect loop")
+	}
+}
+```
+
+- [ ] **Step 2: Port `force_identify_test.go`**
+
+`newResumableSession` builds a `Session` with the resume tuple (`seq`,`sessID`,`resumeURL`,`shardID`,`name`,`stateDB`,`log`) — those stay on `Session`, so drop only the `ctx`/`cancel` fields from the literal (they no longer exist on `Session`). For tests that assert `ForceIdentify` cancels the active connection, attach a conn: `c := s.newConn(ctx, cancel); s.cur.Store(c)` then assert `<-c.ctx.Done()`. For the "signals without mutating resume state" test, the resume-tuple assertions are unchanged (they read `s.sessID` etc.). Where a test previously relied on `s.ctx`/`s.cancel` directly, route through the conn.
+
+- [ ] **Step 3: Give `conn_lifecycle_test.go` its real body**
+
+Replace the skipped `TestSequentialConnsDoNotShareChannels` with a real assertion that two conns from the same Session have distinct channels:
+
+```go
+func TestSequentialConnsDoNotShareChannels(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := s.newConn(ctx, cancel)
+	b := s.newConn(ctx, cancel)
+	if a.wch == b.wch || a.prioch == b.prioch {
+		t.Fatal("two connections share send channels; reconnect can orphan the writer")
+	}
+}
+```
+
+- [ ] **Step 3b: Add acceptance tests for the blessed nil-`cur` behavior (Decision 11)**
+
+These pin the documented behavior changes so they are intentional, not regressions:
+
+```go
+// ForceIdentify with no active connection must still take effect on the next
+// Open: the atomic flag persists even though Cancel is a no-op.
+func TestForceIdentifyWithNilCurStillFlags(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	s.ForceIdentify() // cur is nil
+	if atomic.LoadInt32(&s.forceIdentify) != 1 {
+		t.Fatal("ForceIdentify did not set the flag when no connection was active")
+	}
+}
+
+// RequestGuildMembers is dropped (not buffered) when no connection is active.
+// It must return promptly without panicking on a nil cur.
+func TestRequestGuildMembersDroppedWhenDisconnected(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	done := make(chan struct{})
+	go func() { s.RequestGuildMembers(123); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestGuildMembers blocked on a nil cur")
+	}
+}
+
+// Status/LongLastAck report disconnected when there is no active connection.
+func TestStatusWhenDisconnected(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil), shardID: 9}
+	if got := s.Status(); got == "" {
+		t.Fatal("Status returned empty on nil cur")
+	}
+	if !s.LongLastAck(time.Minute) {
+		t.Fatal("LongLastAck should report true (no acks) on nil cur")
+	}
+}
+```
+
+- [ ] **Step 4: Run the full green gate**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go build ./... \
+  && GOCACHE=/tmp/go-build go vet ./internal/gatewayws/ ./internal/manager/ \
+  && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/ -v 2>&1 | tail -40
+```
+Expected: build clean, vet clean, all tests PASS under `-race`.
+
+- [ ] **Step 5: Commit (the Task 2 + Task 3 change set together)**
+
+```bash
+git add internal/gatewayws/
+git commit -m "refactor(gatewayws): split Session into durable Session + per-Open conn
+
+A fresh conn owns ctx/cancel, wch/prioch, the websocket, buffers and
+heartbeat timing; Session keeps identity, shared deps and the resume tuple
+plus an atomic.Pointer[conn] that management RPCs route through. Removes the
+reconnect-reset hacks (resetHeartbeat, identify-path channel swap, the
+INVALID_SESSION wch rebuild) whose only purpose was scrubbing a reused
+object — a fresh conn cannot inherit stale channels or timestamps."
+```
+
+---
+
+## Task 4: Harden the connection-state synchronization (subsumes review finding #3)
+
+**Files:**
+- Modify: `internal/gatewayws/conn.go` (add `mu`-guarded accessors)
+- Modify: `internal/gatewayws/ws.go` (`Status`, `LongLastAck`, `handleInternalEvent`, `run` state writes)
+- Modify: `internal/gatewayws/write.go` (`sendHeartbeats`, `heartbeatStale`)
+- Modify: `internal/gatewayws/log.go` (`logTotalEvents` curState read)
+- Test: `internal/gatewayws/conn_lifecycle_test.go`
+
+**Interfaces:**
+- Produces on `conn`:
+  ```go
+  func (c *conn) setState(s string)
+  func (c *conn) markAck(t time.Time)
+  func (c *conn) markHB(t time.Time)
+  func (c *conn) markReady(t time.Time)
+  func (c *conn) snapshot() (curState string, lastHB, lastAck, ready time.Time)
+  ```
+  All take/release `c.mu`. `heartbeatStale(now)` reads `lastHB`/`lastAck` under `c.mu` internally.
+
+- [ ] **Step 1: Write a failing race test for concurrent Status during a connection**
+
+```go
+func TestStatusRaceWithConnectionWrites(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil), shardID: 7}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := s.newConn(ctx, cancel)
+	s.cur.Store(c)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			c.setState("handle internal event X")
+			c.markAck(time.Now())
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = s.Status()
+		_ = s.LongLastAck(time.Minute)
+	}
+	<-done
+}
+```
+
+- [ ] **Step 2: Run it under -race and watch it fail**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ -run TestStatusRaceWithConnectionWrites -v
+```
+Expected: `DATA RACE` on `curState`/`lastAck` (raw field access from Step-2-of-Task-2 still unguarded), or compile error if `setState`/`markAck` don't exist yet — either way RED.
+
+- [ ] **Step 3: Add the `mu`-guarded accessors to `conn.go`**
+
+```go
+func (c *conn) setState(s string) { c.mu.Lock(); c.curState = s; c.mu.Unlock() }
+func (c *conn) markHB(t time.Time)  { c.mu.Lock(); c.lastHB = t; c.mu.Unlock() }
+func (c *conn) markAck(t time.Time) { c.mu.Lock(); c.lastAck = t; c.mu.Unlock() }
+func (c *conn) markReady(t time.Time) { c.mu.Lock(); c.ready = t; c.mu.Unlock() }
+
+func (c *conn) snapshot() (curState string, lastHB, lastAck, ready time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.curState, c.lastHB, c.lastAck, c.ready
+}
+```
+
+- [ ] **Step 4: Route every state read/write through the accessors**
+
+  - `run`/`handleInternalEvent`/`readAndDecodeEvent`: every `c.curState = "..."` → `c.setState("...")`.
+  - case 11 (`HEARTBEAT_ACK`): `c.lastAck = time.Now()` → `c.markAck(time.Now())`.
+  - READY/RESUMED/RESUME: `c.ready = time.Now()` → `c.markReady(time.Now())`; `c.authed = true` is already `c.authed.Store(true)`.
+  - `sendHeartbeats`: `c.lastHB = time.Now()` → `c.markHB(time.Now())`; the `s.heartbeatStale(...)` log fields use a `snapshot()`.
+  - `heartbeatStale(now)`: take `c.mu` and read `lastHB`/`lastAck` inside.
+  - `logTotalEvents`: read `curState` via `cur, _, _, _ := c.snapshot()`.
+  - `Status`/`LongLastAck`: use `c.snapshot()` instead of raw reads.
+
+- [ ] **Step 5: Run the race test — now green**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ -run TestStatusRaceWithConnectionWrites -v
+```
+Expected: PASS, no DATA RACE.
+
+- [ ] **Step 6: Full green gate + commit**
+
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go build ./... \
+  && GOCACHE=/tmp/go-build go vet ./internal/gatewayws/ ./internal/manager/ \
+  && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/
+```
+Expected: all green.
+```bash
+git add internal/gatewayws/
+git commit -m "refactor(gatewayws): guard conn timing/state behind a mutex
+
+Status/LongLastAck (manager goroutine) and the read-loop/heartbeat goroutines
+now read and write lastHB/lastAck/ready/curState through mu-guarded accessors,
+closing the pre-existing lastAck/curState data race. authed is an atomic.Bool."
+```
+
+---
+
+## Task 5: Whole-repo verification and review
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full module build + vet + race across all touched packages**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go build ./... \
+  && GOCACHE=/tmp/go-build go vet ./... \
+  && GOCACHE=/tmp/go-build go test -race ./internal/gatewayws/ ./internal/manager/ ./gatewaypb/ 2>&1 | tail -40
+```
+Expected: clean build/vet, all tests PASS.
+
+- [ ] **Step 2: Confirm the external API is byte-for-byte unchanged**
+
+Run:
+```bash
+cd repos/gateway && GOCACHE=/tmp/go-build go doc ./internal/gatewayws Session 2>&1 | grep -E "func .* (Open|Cancel|ForceIdentify|RequestGuildMembers|Status|LongLastAck)\b"
+```
+Expected: the six frozen signatures from Global Constraints, unchanged. Also confirm `internal/manager` still compiles against them (covered by Step 1).
+
+- [ ] **Step 3: Grep for leftover reconnect-reset hacks and stale field access**
+
+Run:
+```bash
+cd repos/gateway && grep -rn "resetHeartbeat\|s\.wch = make\|s\.prioch = make\|len(s\.wch)+len(s\.prioch)" internal/gatewayws/
+```
+Expected: **no matches** (all three hacks removed). Then:
+```bash
+cd repos/gateway && grep -rn "s\.ctx\|s\.cancel\|s\.wsConn\|s\.lastAck\|s\.lastHB\|s\.curState\|s\.wch\|s\.prioch\|s\.authed" internal/gatewayws/*.go | grep -v _test.go
+```
+Expected: no matches — these are now `conn` fields accessed as `c.X`.
+
+- [ ] **Step 4: Self-review the diff against the design**
+
+Run `git diff master...HEAD -- internal/gatewayws/ internal/manager/` and confirm: (a) no behavior change beyond Task 4's synchronization; (b) every method in the migration map landed on the right receiver; (c) `Open` is a thin wrapper, `run` holds the body; (d) management methods nil-guard `s.cur`.
+
+- [ ] **Step 5: Record the outcome in repo artifacts**
+
+Append to `agent-progress.md` and update `feature_list.json` per the repo AGENTS.md Definition of Done (what changed, verification evidence: build/vet/`-race` output, rollback = revert the refactor commits). Do **not** deploy as part of this plan — shipping goes through the staging-deploy skill separately.
+
+---
+
+## Self-Review (plan vs. intent)
+
+- **Codex review pass (2026-06-23):** all 8 must-fix items folded in — `last` atomic-on-Session (Decision 8), `guilds`/`backfilled` stay on Session to survive RESUME (Decision 9), `run(parent)` preserves the two-context split (Decision 10), `s.ctx`→`context.Background()` in Session persistence/load methods (Step 8), `Open` defer cancels before clearing `cur` (Step 7), RGM-drop & Status/LongLastAck nil-`cur` blessed as documented changes (Decision 11), concurrent `Open` unsupported (Decision 12), and the `resetHeartbeat` test rewritten (Task 3 Step 1) with new nil-`cur` acceptance tests (Step 3b).
+- **Coverage:** the captured-channel orphaning (Decision 6, Task 2 Step 7 drops the swap), heartbeat reset loop (Task 2 Step 7 drops `resetHeartbeat`), INVALID_SESSION channel rebuild (Task 2 Step 6), and the `lastAck`/`curState` race (Task 4) are each tied to a concrete step. The frozen external API is verified in Task 5 Step 2.
+- **Type consistency:** accessor names (`setState`, `markHB`, `markAck`, `markReady`, `snapshot`), `newConn(ctx, cancel)`, `(*conn).run`, and `s.cur` are used identically across Tasks 2–5.
+- **Known imperfection (honest):** Task 2 is a single Go type migration that does not compile until its final step — this is inherent to changing a receiver type across a package, not a placeholder. The steps within it are still individually small and ordered; only the *commit* is deferred to the end of Task 3. Every other task is independently green-gated and committed.

--- a/internal/gatewayws/backfill.go
+++ b/internal/gatewayws/backfill.go
@@ -62,20 +62,20 @@ func isFresh(guildID int64, backfilledAt time.Time, base time.Duration) bool {
 // (fresh marker), reconcile a small guild straight from the payload roster, or
 // fall back to RGM. Only the small-guild branch does DB work, and that at most
 // once per guild per staleness window.
-func (s *Session) maybeRequestGuildMembers(ctx context.Context, p *handler.EventPayload) {
+func (c *conn) maybeRequestGuildMembers(ctx context.Context, p *handler.EventPayload) {
 	switch {
-	case s.isBackfilled(p.GuildID):
-		s.log.Debug(ctx, "skipping rgm: backfilled", slog.F("guild", p.GuildID))
+	case c.isBackfilled(p.GuildID):
+		c.s.log.Debug(ctx, "skipping rgm: backfilled", slog.F("guild", p.GuildID))
 	case membersComplete(p, LargeThreshold):
-		if err := s.stateDB.ReconcileGuildMembers(ctx, p.GuildID, p.MemberIDs); err != nil {
-			s.log.Error(ctx, "reconcile guild members", slog.Error(err), slog.F("guild", p.GuildID))
+		if err := c.s.stateDB.ReconcileGuildMembers(ctx, p.GuildID, p.MemberIDs); err != nil {
+			c.s.log.Error(ctx, "reconcile guild members", slog.Error(err), slog.F("guild", p.GuildID))
 		}
 	default:
-		s.requestGuildMembers(p.GuildID)
+		c.requestGuildMembers(p.GuildID)
 	}
 }
 
-func (s *Session) isBackfilled(guildID int64) bool {
-	_, ok := s.backfilled[guildID] // nil-map read is safe and returns false
+func (c *conn) isBackfilled(guildID int64) bool {
+	_, ok := c.s.backfilled[guildID] // nil-map read is safe and returns false
 	return ok
 }

--- a/internal/gatewayws/conn.go
+++ b/internal/gatewayws/conn.go
@@ -56,3 +56,38 @@ func (s *Session) newConn(ctx context.Context, cancel context.CancelFunc) *conn 
 		prioch: make(chan *Op),
 	}
 }
+
+// The accessors below guard the timing/state fields: the read-loop and
+// heartbeat goroutines write them while Status/LongLastAck (manager goroutine)
+// read them.
+
+func (c *conn) setState(state string) {
+	c.mu.Lock()
+	c.curState = state
+	c.mu.Unlock()
+}
+
+func (c *conn) markHB(t time.Time) {
+	c.mu.Lock()
+	c.lastHB = t
+	c.mu.Unlock()
+}
+
+func (c *conn) markAck(t time.Time) {
+	c.mu.Lock()
+	c.lastAck = t
+	c.mu.Unlock()
+}
+
+func (c *conn) markReady(t time.Time) {
+	c.mu.Lock()
+	c.ready = t
+	c.mu.Unlock()
+}
+
+// snapshot returns the guarded state fields in one locked read.
+func (c *conn) snapshot() (curState string, lastHB, lastAck, ready time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.curState, c.lastHB, c.lastAck, c.ready
+}

--- a/internal/gatewayws/conn.go
+++ b/internal/gatewayws/conn.go
@@ -1,0 +1,58 @@
+package gatewayws
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/etcd-io/etcd/clientv3/concurrency"
+	"nhooyr.io/websocket"
+)
+
+// conn is a single gateway connection. A fresh conn is built per Open and
+// discarded when that connection dies, so connection-scoped state (channels,
+// socket, heartbeat timing) can never leak across reconnects.
+type conn struct {
+	s *Session
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wsConn *websocket.Conn
+	zr     io.ReadCloser
+
+	interval time.Duration
+	trace    string
+
+	wch    chan *Op
+	prioch chan *Op
+
+	buf *bytes.Buffer
+
+	etcdSess   *concurrency.Session
+	identifyMu *concurrency.Mutex
+
+	authed atomic.Bool
+
+	// mu guards the timing/state fields below, which are read by management
+	// calls (Status/LongLastAck) on the manager goroutine while the read-loop
+	// and heartbeat goroutines write them. Accessors are added in Task 4.
+	mu       sync.Mutex
+	lastHB   time.Time
+	lastAck  time.Time
+	ready    time.Time
+	curState string
+}
+
+func (s *Session) newConn(ctx context.Context, cancel context.CancelFunc) *conn {
+	return &conn{
+		s:      s,
+		ctx:    ctx,
+		cancel: cancel,
+		wch:    make(chan *Op, 2000),
+		prioch: make(chan *Op),
+	}
+}

--- a/internal/gatewayws/conn_lifecycle_test.go
+++ b/internal/gatewayws/conn_lifecycle_test.go
@@ -57,3 +57,28 @@ func TestStatusWhenDisconnected(t *testing.T) {
 		t.Fatal("LongLastAck should report true (no acks) on nil cur")
 	}
 }
+
+// Status/LongLastAck run on the manager goroutine while the read-loop and
+// heartbeat goroutines write curState/lastAck/lastHB. Those reads and writes
+// must go through the conn mutex; -race fails here otherwise.
+func TestStatusRaceWithConnectionWrites(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil), shardID: 7}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := s.newConn(ctx, cancel)
+	s.cur.Store(c)
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			c.setState("handle internal event X")
+			c.markAck(time.Now())
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		_ = s.Status()
+		_ = s.LongLastAck(time.Minute)
+	}
+	<-done
+}

--- a/internal/gatewayws/conn_lifecycle_test.go
+++ b/internal/gatewayws/conn_lifecycle_test.go
@@ -1,0 +1,11 @@
+package gatewayws
+
+import "testing"
+
+// After the conn refactor, two sequential connections must not share send
+// channels: a fresh conn allocates its own wch/prioch, so a producer for
+// connection B can never reach connection A's writer (the captured-locals
+// orphaning bug). Re-enabled with a real body in Task 4 once conn exists.
+func TestSequentialConnsDoNotShareChannels(t *testing.T) {
+	t.Skip("enabled in Task 3 after conn type exists")
+}

--- a/internal/gatewayws/conn_lifecycle_test.go
+++ b/internal/gatewayws/conn_lifecycle_test.go
@@ -1,11 +1,59 @@
 package gatewayws
 
-import "testing"
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"cdr.dev/slog/sloggers/slogtest"
+)
 
 // After the conn refactor, two sequential connections must not share send
 // channels: a fresh conn allocates its own wch/prioch, so a producer for
 // connection B can never reach connection A's writer (the captured-locals
-// orphaning bug). Re-enabled with a real body in Task 4 once conn exists.
+// orphaning bug).
 func TestSequentialConnsDoNotShareChannels(t *testing.T) {
-	t.Skip("enabled in Task 3 after conn type exists")
+	s := &Session{log: slogtest.Make(t, nil)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := s.newConn(ctx, cancel)
+	b := s.newConn(ctx, cancel)
+	if a.wch == b.wch || a.prioch == b.prioch {
+		t.Fatal("two connections share send channels; reconnect can orphan the writer")
+	}
+}
+
+// ForceIdentify with no active connection must still take effect on the next
+// Open: the atomic flag persists even though Cancel is a no-op.
+func TestForceIdentifyWithNilCurStillFlags(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	s.ForceIdentify() // cur is nil
+	if atomic.LoadInt32(&s.forceIdentify) != 1 {
+		t.Fatal("ForceIdentify did not set the flag when no connection was active")
+	}
+}
+
+// RequestGuildMembers is dropped (not buffered) when no connection is active.
+// It must return promptly without panicking on a nil cur.
+func TestRequestGuildMembersDroppedWhenDisconnected(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	done := make(chan struct{})
+	go func() { s.RequestGuildMembers(123); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestGuildMembers blocked on a nil cur")
+	}
+}
+
+// Status/LongLastAck report disconnected when there is no active connection.
+func TestStatusWhenDisconnected(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil), shardID: 9}
+	if got := s.Status(); got == "" {
+		t.Fatal("Status returned empty on nil cur")
+	}
+	if !s.LongLastAck(time.Minute) {
+		t.Fatal("LongLastAck should report true (no acks) on nil cur")
+	}
 }

--- a/internal/gatewayws/conn_lifecycle_test.go
+++ b/internal/gatewayws/conn_lifecycle_test.go
@@ -47,6 +47,24 @@ func TestRequestGuildMembersDroppedWhenDisconnected(t *testing.T) {
 	}
 }
 
+// The automatic GUILD_CREATE backfill path runs under the parent ctx, so a
+// disconnect mid-event can reach requestGuildMembers with a torn-down conn
+// whose writer has already exited. It must drop the request (and log), not
+// silently enqueue it into a dead wch the next Open replaces — that orphaned
+// op would never be sent and the large guild would never get a member backfill.
+func TestAutoRequestGuildMembersDroppedOnTornDownConn(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	ctx, cancel := context.WithCancel(context.Background())
+	c := s.newConn(ctx, cancel)
+	cancel() // simulate the connection being torn down before the RGM enqueue
+
+	c.requestGuildMembers(123)
+
+	if n := len(c.wch); n != 0 {
+		t.Fatalf("requestGuildMembers orphaned %d op(s) into a dead wch; want 0 (dropped)", n)
+	}
+}
+
 // Status/LongLastAck report disconnected when there is no active connection.
 func TestStatusWhenDisconnected(t *testing.T) {
 	s := &Session{log: slogtest.Make(t, nil), shardID: 9}

--- a/internal/gatewayws/force_identify_test.go
+++ b/internal/gatewayws/force_identify_test.go
@@ -34,11 +34,11 @@ func (r *shardInfoRecorder) SetShardInfo(ctx context.Context, shard int, name st
 	return nil
 }
 
-func newResumableSession(t *testing.T, db state.DB) (*Session, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
+// newResumableSession builds a resumable Session with a live connection
+// published to cur, so ForceIdentify/Cancel route to it. Returns the conn so a
+// test can observe its context being cancelled.
+func newResumableSession(t *testing.T, db state.DB) (*Session, *conn) {
 	s := &Session{
-		ctx:       ctx,
-		cancel:    cancel,
 		log:       slogtest.Make(t, nil),
 		stateDB:   db,
 		shardID:   42,
@@ -50,7 +50,11 @@ func newResumableSession(t *testing.T, db state.DB) (*Session, context.CancelFun
 	if !s.shouldResume() {
 		t.Fatal("test setup must start with a resumable session")
 	}
-	return s, cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	c := s.newConn(ctx, cancel)
+	s.cur.Store(c)
+	return s, c
 }
 
 // ForceIdentify only signals: it sets the flag and cancels the active
@@ -59,7 +63,7 @@ func newResumableSession(t *testing.T, db state.DB) (*Session, context.CancelFun
 // persist directly — persistShardInfo is flag-aware instead.
 func TestForceIdentifySignalsWithoutMutatingResumeState(t *testing.T) {
 	db := &shardInfoRecorder{}
-	s, _ := newResumableSession(t, db)
+	s, c := newResumableSession(t, db)
 
 	s.ForceIdentify()
 
@@ -74,7 +78,7 @@ func TestForceIdentifySignalsWithoutMutatingResumeState(t *testing.T) {
 		t.Fatalf("ForceIdentify persisted directly (calls=%d); persistence must go through the read loop", db.calls)
 	}
 	select {
-	case <-s.ctx.Done():
+	case <-c.ctx.Done():
 	default:
 		t.Fatal("ForceIdentify did not cancel the active shard context")
 	}

--- a/internal/gatewayws/heartbeat_deadlock_test.go
+++ b/internal/gatewayws/heartbeat_deadlock_test.go
@@ -18,20 +18,23 @@ import (
 func TestWriterCancelsConnectionWhenItExits(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Session{
-		ctx:    ctx,
-		cancel: cancel,
-		log:    slogtest.Make(t, nil),
+		log: slogtest.Make(t, nil),
 		// burst 0 => rl.Wait(ctx) returns an error immediately, driving writer()
 		// down its abnormal-exit path without needing a real websocket.
-		rl:     rate.NewLimiter(rate.Every(time.Hour), 0),
+		rl: rate.NewLimiter(rate.Every(time.Hour), 0),
+	}
+	c := &conn{
+		s:      s,
+		ctx:    ctx,
+		cancel: cancel,
 		wch:    make(chan *Op, 1),
 		prioch: make(chan *Op, 1),
-		authed: true,
 	}
-	s.prioch <- &Op{Op: 1} // give writer a message so it advances to rl.Wait and exits
+	c.authed.Store(true)
+	c.prioch <- &Op{Op: 1} // give writer a message so it advances to rl.Wait and exits
 
 	done := make(chan struct{})
-	go func() { s.writer(); close(done) }()
+	go func() { c.writer(); close(done) }()
 
 	select {
 	case <-done:
@@ -40,7 +43,7 @@ func TestWriterCancelsConnectionWhenItExits(t *testing.T) {
 	}
 
 	select {
-	case <-s.ctx.Done():
+	case <-c.ctx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("writer exited without cancelling the connection context; the read loop can deadlock on prioch")
 	}
@@ -52,17 +55,18 @@ func TestWriterCancelsConnectionWhenItExits(t *testing.T) {
 // reconnect.
 func TestWriteHeartbeatUnblocksWhenContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	s := &Session{
+	s := &Session{log: slogtest.Make(t, nil)}
+	c := &conn{
+		s:      s,
 		ctx:    ctx,
 		cancel: cancel,
-		log:    slogtest.Make(t, nil),
 		prioch: make(chan *Op), // unbuffered, no receiver: a bare send would wedge
 	}
 	cancel() // connection is being torn down
 
 	done := make(chan struct{})
 	go func() {
-		s.writeHeartbeat()
+		c.writeHeartbeat()
 		close(done)
 	}()
 
@@ -73,17 +77,18 @@ func TestWriteHeartbeatUnblocksWhenContextCancelled(t *testing.T) {
 	}
 }
 
-// assertUnblocksOnCancel runs a Session send method with no receiver draining
+// assertUnblocksOnCancel runs a conn send method with no receiver draining
 // prioch/wch and a cancelled connection context, and fails if it doesn't return
 // promptly. A bare channel send would deadlock here exactly as writeHeartbeat
 // did; every gateway-initiated send must abort on ctx.Done instead.
-func assertUnblocksOnCancel(t *testing.T, name string, run func(*Session)) {
+func assertUnblocksOnCancel(t *testing.T, name string, run func(*conn)) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	s := &Session{
+	s := &Session{log: slogtest.Make(t, nil)}
+	c := &conn{
+		s:      s,
 		ctx:    ctx,
 		cancel: cancel,
-		log:    slogtest.Make(t, nil),
 		prioch: make(chan *Op),
 		wch:    make(chan *Op),
 	}
@@ -91,7 +96,7 @@ func assertUnblocksOnCancel(t *testing.T, name string, run func(*Session)) {
 
 	done := make(chan struct{})
 	go func() {
-		run(s)
+		run(c)
 		close(done)
 	}()
 
@@ -103,15 +108,15 @@ func assertUnblocksOnCancel(t *testing.T, name string, run func(*Session)) {
 }
 
 func TestWriteIdentifyUnblocksOnCancel(t *testing.T) {
-	assertUnblocksOnCancel(t, "writeIdentify", (*Session).writeIdentify)
+	assertUnblocksOnCancel(t, "writeIdentify", (*conn).writeIdentify)
 }
 
 func TestWriteResumeUnblocksOnCancel(t *testing.T) {
-	assertUnblocksOnCancel(t, "writeResume", (*Session).writeResume)
+	assertUnblocksOnCancel(t, "writeResume", (*conn).writeResume)
 }
 
 func TestRequestGuildMembersUnblocksOnCancel(t *testing.T) {
-	assertUnblocksOnCancel(t, "RequestGuildMembers", func(s *Session) { s.RequestGuildMembers(123) })
+	assertUnblocksOnCancel(t, "requestGuildMembersExternal", func(c *conn) { c.requestGuildMembersExternal(123) })
 }
 
 // heartbeatStale is the watchdog's death signal: a heartbeat we sent has gone
@@ -124,10 +129,10 @@ func TestHeartbeatStale(t *testing.T) {
 	base := time.Now()
 
 	cases := []struct {
-		name           string
+		name            string
 		lastHB, lastAck time.Time
-		now            time.Time
-		want           bool
+		now             time.Time
+		want            bool
 	}{
 		{"never sent a heartbeat", time.Time{}, time.Time{}, base, false},
 		{"acked promptly", base, base.Add(time.Millisecond), base.Add(interval), false},
@@ -136,34 +141,29 @@ func TestHeartbeatStale(t *testing.T) {
 		{"first heartbeat never acked", base, time.Time{}, base.Add(interval), true},
 	}
 
-	for _, c := range cases {
-		s := &Session{lastHB: c.lastHB, lastAck: c.lastAck, interval: interval}
-		if got := s.heartbeatStale(c.now); got != c.want {
-			t.Errorf("%s: heartbeatStale(%v) = %v, want %v", c.name, c.now, got, c.want)
+	for _, tc := range cases {
+		c := &conn{lastHB: tc.lastHB, lastAck: tc.lastAck, interval: interval}
+		if got := c.heartbeatStale(tc.now); got != tc.want {
+			t.Errorf("%s: heartbeatStale(%v) = %v, want %v", tc.name, tc.now, got, tc.want)
 		}
 	}
 }
 
-// A Session is reused across reconnects, so heartbeat state from the previous
-// connection must be cleared when a new one starts. If lastHB carried over while
-// lastAck is reset to zero, heartbeatStale would read that old heartbeat as
-// unacked and cancel the fresh connection on its first tick — a reconnect loop.
-// resetHeartbeat must clear both timestamps together.
-func TestResetHeartbeatPreventsStaleCancelAfterReconnect(t *testing.T) {
-	old := time.Now().Add(-time.Hour)
-	s := &Session{
-		lastHB:   old,                      // heartbeat sent on the previous connection
-		lastAck:  old.Add(10 * time.Millisecond), // and acked then
-		interval: 40 * time.Second,
+// A fresh conn must start with zero heartbeat state so the watchdog cannot fire
+// on its first tick. This replaces the old resetHeartbeat test: where a reused
+// Session needed an explicit reset to avoid a reconnect loop, a per-Open conn
+// gets zero-valued lastHB/lastAck for free from newConn.
+func TestFreshConnHasZeroHeartbeatState(t *testing.T) {
+	s := &Session{log: slogtest.Make(t, nil)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := s.newConn(ctx, cancel)
+	c.interval = 40 * time.Second
+	if !c.lastHB.IsZero() || !c.lastAck.IsZero() {
+		t.Fatalf("fresh conn carried heartbeat state: lastHB=%v lastAck=%v", c.lastHB, c.lastAck)
 	}
-
-	s.resetHeartbeat()
-
-	if !s.lastHB.IsZero() || !s.lastAck.IsZero() {
-		t.Fatalf("resetHeartbeat left state: lastHB=%v lastAck=%v", s.lastHB, s.lastAck)
-	}
-	if s.heartbeatStale(time.Now()) {
-		t.Fatal("heartbeatStale fired on a freshly reset connection; would cause a reconnect loop")
+	if c.heartbeatStale(time.Now()) {
+		t.Fatal("heartbeatStale fired on a fresh connection; would cause a reconnect loop")
 	}
 }
 
@@ -172,17 +172,18 @@ func TestResetHeartbeatPreventsStaleCancelAfterReconnect(t *testing.T) {
 func TestWriteHeartbeatDeliversWhenDrained(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	s := &Session{
+	s := &Session{log: slogtest.Make(t, nil)}
+	c := &conn{
+		s:      s,
 		ctx:    ctx,
 		cancel: cancel,
-		log:    slogtest.Make(t, nil),
 		prioch: make(chan *Op),
 	}
 
-	go s.writeHeartbeat()
+	go c.writeHeartbeat()
 
 	select {
-	case op := <-s.prioch:
+	case op := <-c.prioch:
 		if op.Op != 1 {
 			t.Fatalf("heartbeat op = %d, want 1", op.Op)
 		}

--- a/internal/gatewayws/hello.go
+++ b/internal/gatewayws/hello.go
@@ -7,24 +7,24 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func (s *Session) readHello() error {
-	s.buf = s.bufferPool.Get().(*bytes.Buffer)
-	defer s.cleanupBuffer()
+func (c *conn) readHello() error {
+	c.buf = c.s.bufferPool.Get().(*bytes.Buffer)
+	defer c.cleanupBuffer()
 
-	err := s.readMessage()
+	err := c.readMessage()
 	if err != nil {
 		return xerrors.Errorf("read message: %w", err)
 	}
 
-	interval, trace, err := s.enc.DecodeHello(s.buf.Bytes())
+	interval, trace, err := c.s.enc.DecodeHello(c.buf.Bytes())
 	if err != nil {
 		return xerrors.Errorf("decode hello message: %w", err)
 	}
 	if interval <= 0 {
 		return xerrors.Errorf("invalid interval received: %d", interval)
 	}
-	s.interval = time.Duration(interval) * time.Millisecond
-	s.trace = trace
+	c.interval = time.Duration(interval) * time.Millisecond
+	c.trace = trace
 
 	return nil
 }

--- a/internal/gatewayws/log.go
+++ b/internal/gatewayws/log.go
@@ -28,6 +28,7 @@ func (c *conn) logTotalEvents() {
 		case <-logT.C:
 			seq := atomic.LoadInt64(&c.s.seq)
 			since := seq - atomic.LoadInt64(&c.s.last)
+			curState, _, _, _ := c.snapshot()
 
 			c.s.log.Info(
 				c.ctx,
@@ -37,12 +38,13 @@ func (c *conn) logTotalEvents() {
 				slog.F("/sec", float64(since)/LogInterval.Seconds()),
 				slog.F("write_queue", len(c.wch)),
 				slog.F("waiting", c.s.state.WaitingQueries()),
-				slog.F("state", c.curState),
+				slog.F("state", curState),
 			)
-			c.s.persistStatus(c.curState)
+			c.s.persistStatus(curState)
 			atomic.StoreInt64(&c.s.last, seq)
 		case <-statusT.C:
-			c.s.persistStatus(c.curState)
+			curState, _, _, _ := c.snapshot()
+			c.s.persistStatus(curState)
 		}
 	}
 }

--- a/internal/gatewayws/log.go
+++ b/internal/gatewayws/log.go
@@ -12,11 +12,11 @@ const (
 	StatusInterval = 1 * time.Minute
 )
 
-func (s *Session) logTotalEvents() {
+func (c *conn) logTotalEvents() {
 	var (
 		logT    = time.NewTicker(LogInterval)
 		statusT = time.NewTicker(StatusInterval)
-		ctx     = s.ctx
+		ctx     = c.ctx
 	)
 	defer logT.Stop()
 	defer statusT.Stop()
@@ -26,23 +26,23 @@ func (s *Session) logTotalEvents() {
 		case <-ctx.Done():
 			return
 		case <-logT.C:
-			seq := atomic.LoadInt64(&s.seq)
-			since := seq - s.last
+			seq := atomic.LoadInt64(&c.s.seq)
+			since := seq - atomic.LoadInt64(&c.s.last)
 
-			s.log.Info(
-				s.ctx,
+			c.s.log.Info(
+				c.ctx,
 				"event report",
 				slog.F("seq", seq),
 				slog.F("events", since),
 				slog.F("/sec", float64(since)/LogInterval.Seconds()),
-				slog.F("write_queue", len(s.wch)),
-				slog.F("waiting", s.state.WaitingQueries()),
-				slog.F("state", s.curState),
+				slog.F("write_queue", len(c.wch)),
+				slog.F("waiting", c.s.state.WaitingQueries()),
+				slog.F("state", c.curState),
 			)
-			s.persistStatus()
-			s.last = seq
+			c.s.persistStatus(c.curState)
+			atomic.StoreInt64(&c.s.last, seq)
 		case <-statusT.C:
-			s.persistStatus()
+			c.s.persistStatus(c.curState)
 		}
 	}
 }

--- a/internal/gatewayws/persistence.go
+++ b/internal/gatewayws/persistence.go
@@ -20,7 +20,7 @@ func (s *Session) persistShardInfo() {
 	}
 	err := s.stateDB.SetShardInfo(context.Background(), s.shardID, s.name, seq, sessID, resumeURL)
 	if err != nil {
-		s.log.Error(s.ctx, "save shard info", slog.Error(err))
+		s.log.Error(context.Background(), "save shard info", slog.Error(err))
 	}
 }
 
@@ -28,7 +28,7 @@ func (s *Session) loadSeq() {
 	var err error
 	s.seq, err = s.stateDB.GetSequence(context.Background(), s.shardID, s.name)
 	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
-		s.log.Error(s.ctx, "load session id", slog.Error(err))
+		s.log.Error(context.Background(), "load session id", slog.Error(err))
 	}
 }
 
@@ -36,22 +36,22 @@ func (s *Session) loadSessID() {
 	var err error
 	s.sessID, err = s.stateDB.GetSessionID(context.Background(), s.shardID, s.name)
 	if err != nil && !xerrors.Is(err, sql.ErrNoRows) {
-		s.log.Error(s.ctx, "load session id", slog.Error(err))
+		s.log.Error(context.Background(), "load session id", slog.Error(err))
 	}
 }
 
 func (s *Session) loadResumeURL() {
 	url, err := s.stateDB.GetResumeGatewayURL(context.Background(), s.shardID, s.name)
 	if err != nil {
-		s.log.Error(s.ctx, "load resume gateway url", slog.Error(err))
+		s.log.Error(context.Background(), "load resume gateway url", slog.Error(err))
 		return
 	}
 	s.resumeURL = url
 }
 
-func (s *Session) persistStatus() {
-	err := s.stateDB.SetStatus(context.Background(), s.shardID, s.name, s.curState)
+func (s *Session) persistStatus(state string) {
+	err := s.stateDB.SetStatus(context.Background(), s.shardID, s.name, state)
 	if err != nil {
-		s.log.Error(s.ctx, "save status", slog.Error(err))
+		s.log.Error(context.Background(), "save status", slog.Error(err))
 	}
 }

--- a/internal/gatewayws/read.go
+++ b/internal/gatewayws/read.go
@@ -12,28 +12,28 @@ import (
 
 const connectionTimeout = 30
 
-// readMessage populates buf on *Session with the next message.
-func (s *Session) readMessage() error {
+// readMessage populates buf on *conn with the next message.
+func (c *conn) readMessage() error {
 	start := time.Now()
 	defer func() {
 		took := time.Since(start)
 		if took > connectionTimeout*time.Second {
-			s.log.Error(s.ctx, "took too long to get reader", slog.F("took", time.Since(start).String()))
+			c.s.log.Error(c.ctx, "took too long to get reader", slog.F("took", time.Since(start).String()))
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(s.ctx, connectionTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(c.ctx, connectionTimeout*time.Second)
 	defer cancel()
 
-	_, r, err := s.wsConn.Reader(ctx)
+	_, r, err := c.wsConn.Reader(ctx)
 	if err != nil {
 		return xerrors.Errorf("get ws reader: %w", err)
 	}
 
-	s.zr.(czlib.Resetter).Reset(r)
-	defer s.zr.Close()
+	c.zr.(czlib.Resetter).Reset(r)
+	defer c.zr.Close()
 
-	_, err = s.buf.ReadFrom(s.zr)
+	_, err = c.buf.ReadFrom(c.zr)
 	if err != nil {
 		return xerrors.Errorf("copy message: %w", err)
 	}

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -16,18 +16,18 @@ type Op struct {
 	D  interface{} `json:"d"`
 }
 
-func (s *Session) writer() {
+func (c *conn) writer() {
 	var (
-		ctx    = s.ctx
-		wch    = s.wch
-		prioch = s.prioch
+		ctx    = c.ctx
+		wch    = c.wch
+		prioch = c.prioch
 		isPrio bool
 	)
 
 	// A dead writer means the connection is unusable. Cancel it on exit so the
 	// read loop and sendHeartbeats can't block forever on the unbuffered
 	// prioch/wch sends (nothing else drains them once writer is gone).
-	defer s.Cancel()
+	defer c.cancel()
 
 	for {
 		var msg *Op
@@ -39,24 +39,24 @@ func (s *Session) writer() {
 		case msg = <-prioch:
 			isPrio = true
 		case msg = <-wch:
-			if !s.authed {
+			if !c.authed.Load() {
 				wch <- msg
 				time.Sleep(25 * time.Millisecond)
 				continue
 			}
 		}
 
-		err := s.rl.Wait(ctx)
+		err := c.s.rl.Wait(ctx)
 		if err != nil {
 			return
 		}
 
-		err = s.writeOp(msg)
+		err = c.writeOp(msg)
 		if err != nil {
 			if !isPrio {
 				wch <- msg
 			}
-			s.log.Error(s.ctx, "write ws message", slog.Error(err), slog.F("op", msg.Op))
+			c.s.log.Error(c.ctx, "write ws message", slog.Error(err), slog.F("op", msg.Op))
 			return
 		}
 		isPrio = false
@@ -64,8 +64,8 @@ func (s *Session) writer() {
 	}
 }
 
-func (s *Session) writeOp(op *Op) error {
-	raw, err := s.enc.Write(*op)
+func (c *conn) writeOp(op *Op) error {
+	raw, err := c.s.enc.Write(*op)
 	if err != nil {
 		return xerrors.Errorf("encode op: %w", err)
 	}
@@ -73,14 +73,14 @@ func (s *Session) writeOp(op *Op) error {
 	// Bound the write the same way readMessage bounds the read. Without a
 	// deadline a black-holed socket (remote stopped reading, send buffer full)
 	// blocks here indefinitely: the writer never returns, never reaches its
-	// defer s.Cancel(), and the read loop wedges on the unbuffered prioch send
+	// defer c.cancel(), and the read loop wedges on the unbuffered prioch send
 	// inside writeHeartbeat — the "handle internal event " freeze seen in prod.
 	// With the deadline a stuck write fails, the writer exits and cancels the
 	// connection, and the read loop unwinds and reconnects.
-	ctx, cancel := context.WithTimeout(s.ctx, connectionTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(c.ctx, connectionTimeout*time.Second)
 	defer cancel()
 
-	w, err := s.wsConn.Writer(ctx, websocket.MessageBinary)
+	w, err := c.wsConn.Writer(ctx, websocket.MessageBinary)
 	if err != nil {
 		return xerrors.Errorf("get writer: %w", err)
 	}
@@ -121,14 +121,14 @@ type updatePresence struct {
 	AFK        bool        `json:"afk"`
 }
 
-func (s *Session) writeIdentify() {
+func (c *conn) writeIdentify() {
 	select {
-	case <-s.ctx.Done():
+	case <-c.ctx.Done():
 		return
-	case s.prioch <- &Op{
+	case c.prioch <- &Op{
 		Op: 2,
 		D: Identify{
-			Token: s.token,
+			Token: c.s.token,
 			Properties: Props{
 				Os:      runtime.GOOS,
 				Browser: "https://github.com/tatsuworks/gateway",
@@ -136,8 +136,8 @@ func (s *Session) writeIdentify() {
 			},
 			Compress:       false,
 			LargeThreshold: LargeThreshold,
-			Shard:          []int{s.shardID, s.shardCount},
-			Intents:        s.intents.Collect(),
+			Shard:          []int{c.s.shardID, c.s.shardCount},
+			Intents:        c.s.intents.Collect(),
 			Presence: updatePresence{
 				Activities: []*activity{
 					{
@@ -158,40 +158,30 @@ type Resume struct {
 	Sequence  int64  `json:"seq"`
 }
 
-func (s *Session) writeResume() {
+func (c *conn) writeResume() {
 	select {
-	case <-s.ctx.Done():
-	case s.prioch <- &Op{
+	case <-c.ctx.Done():
+	case c.prioch <- &Op{
 		Op: 6,
 		D: Resume{
-			Token:     s.token,
-			SessionID: s.sessID,
-			Sequence:  atomic.LoadInt64(&s.seq),
+			Token:     c.s.token,
+			SessionID: c.s.sessID,
+			Sequence:  atomic.LoadInt64(&c.s.seq),
 		},
 	}:
 	}
 }
 
-func (s *Session) writeHeartbeat() {
+func (c *conn) writeHeartbeat() {
 	// Abort if the connection is being torn down. prioch is unbuffered, so a bare
 	// send wedges the read loop forever once writer() has exited.
 	select {
-	case s.prioch <- &Op{
+	case c.prioch <- &Op{
 		Op: 1,
-		D:  atomic.LoadInt64(&s.seq),
+		D:  atomic.LoadInt64(&c.s.seq),
 	}:
-	case <-s.ctx.Done():
+	case <-c.ctx.Done():
 	}
-}
-
-// resetHeartbeat clears heartbeat tracking for a new connection. Both timestamps
-// must be cleared together: a Session is reused across reconnects, so a lastHB
-// left over from the previous connection (while lastAck is reset to zero) would
-// make heartbeatStale fire on the first tick and cancel the fresh connection
-// before it ever heartbeats — a reconnect loop.
-func (s *Session) resetHeartbeat() {
-	s.lastHB = time.Time{}
-	s.lastAck = time.Time{}
 }
 
 // heartbeatStale reports whether the most recent heartbeat we sent has gone
@@ -201,18 +191,18 @@ func (s *Session) resetHeartbeat() {
 // after lastHB). Measuring "time since the unacked send" rather than
 // lastAck.Sub(lastHB) is deliberate: once ACKs stop, lastAck falls behind lastHB
 // and the old difference went negative, so the watchdog could never fire.
-func (s *Session) heartbeatStale(now time.Time) bool {
-	if s.lastHB.IsZero() {
+func (c *conn) heartbeatStale(now time.Time) bool {
+	if c.lastHB.IsZero() {
 		return false
 	}
-	return s.lastHB.After(s.lastAck) && now.Sub(s.lastHB) >= s.interval
+	return c.lastHB.After(c.lastAck) && now.Sub(c.lastHB) >= c.interval
 }
 
-func (s *Session) sendHeartbeats() {
+func (c *conn) sendHeartbeats() {
 	var (
-		t      = time.NewTicker(s.interval)
-		ctx    = s.ctx
-		cancel = s.cancel
+		t      = time.NewTicker(c.interval)
+		ctx    = c.ctx
+		cancel = c.cancel
 	)
 	defer t.Stop()
 
@@ -223,15 +213,15 @@ func (s *Session) sendHeartbeats() {
 		case <-t.C:
 		}
 
-		if s.heartbeatStale(time.Now()) {
-			s.log.Warn(s.ctx, "no response to heartbeat; tearing down connection",
-				slog.F("last_hb", s.lastHB), slog.F("last_ack", s.lastAck))
+		if c.heartbeatStale(time.Now()) {
+			c.s.log.Warn(c.ctx, "no response to heartbeat; tearing down connection",
+				slog.F("last_hb", c.lastHB), slog.F("last_ack", c.lastAck))
 			cancel()
 			return
 		}
 
-		s.writeHeartbeat()
-		s.lastHB = time.Now()
+		c.writeHeartbeat()
+		c.lastHB = time.Now()
 	}
 }
 
@@ -241,16 +231,16 @@ type RequestGuildMembers struct {
 	Limit   int    `json:"limit"`
 }
 
-func (s *Session) requestGuildMembers(guild int64) {
+func (c *conn) requestGuildMembers(guild int64) {
 	select {
-	case s.wch <- &Op{
+	case c.wch <- &Op{
 		Op: 8,
 		D: RequestGuildMembers{
 			GuildID: guild,
 		},
 	}:
 	default:
-		s.log.Error(s.ctx, "write channel full")
+		c.s.log.Error(c.ctx, "write channel full")
 	}
 
 }
@@ -260,9 +250,9 @@ type activity struct {
 	Type int    `json:"type"`
 }
 
-func (s *Session) rotateStatuses() {
+func (c *conn) rotateStatuses() {
 	var (
-		ctx      = s.ctx
+		ctx      = c.ctx
 		statuses = []string{
 			"Use t!help",
 			"https://tatsu.gg",
@@ -279,9 +269,9 @@ func (s *Session) rotateStatuses() {
 			default:
 			}
 
-			s.log.Debug(s.ctx, "writing status", slog.F("status", e))
+			c.s.log.Debug(c.ctx, "writing status", slog.F("status", e))
 
-			s.wch <- &Op{
+			c.wch <- &Op{
 				Op: 3,
 				D: updatePresence{
 					Activities: []*activity{
@@ -298,7 +288,10 @@ func (s *Session) rotateStatuses() {
 	}
 }
 
-func (s *Session) RequestGuildMembers(guildID int64) {
+// requestGuildMembersExternal is the management-RPC path (gRPC). Unlike the
+// internal default-drop variant it blocks on the send, aborting only if the
+// connection is torn down.
+func (c *conn) requestGuildMembersExternal(guildID int64) {
 	op := &Op{
 		Op: 8,
 		D: RequestGuildMembers{
@@ -306,9 +299,9 @@ func (s *Session) RequestGuildMembers(guildID int64) {
 		},
 	}
 
-	s.log.Info(s.ctx, "sending members request", slog.F("guild", guildID))
+	c.s.log.Info(c.ctx, "sending members request", slog.F("guild", guildID))
 	select {
-	case s.wch <- op:
-	case <-s.ctx.Done():
+	case c.wch <- op:
+	case <-c.ctx.Done():
 	}
 }

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -192,6 +192,8 @@ func (c *conn) writeHeartbeat() {
 // lastAck.Sub(lastHB) is deliberate: once ACKs stop, lastAck falls behind lastHB
 // and the old difference went negative, so the watchdog could never fire.
 func (c *conn) heartbeatStale(now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.lastHB.IsZero() {
 		return false
 	}
@@ -214,14 +216,15 @@ func (c *conn) sendHeartbeats() {
 		}
 
 		if c.heartbeatStale(time.Now()) {
+			_, lastHB, lastAck, _ := c.snapshot()
 			c.s.log.Warn(c.ctx, "no response to heartbeat; tearing down connection",
-				slog.F("last_hb", c.lastHB), slog.F("last_ack", c.lastAck))
+				slog.F("last_hb", lastHB), slog.F("last_ack", lastAck))
 			cancel()
 			return
 		}
 
 		c.writeHeartbeat()
-		c.lastHB = time.Now()
+		c.markHB(time.Now())
 	}
 }
 

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -235,6 +235,17 @@ type RequestGuildMembers struct {
 }
 
 func (c *conn) requestGuildMembers(guild int64) {
+	// If the connection is torn down the writer has already exited and the next
+	// Open allocates a fresh wch, so a send here (this path is non-blocking and
+	// the buffer usually has room) is silently orphaned. This path runs under
+	// the parent ctx, so a disconnect mid-GUILD_CREATE still reaches here with a
+	// dead conn. Drop + log instead. The guild is re-requested on the next
+	// IDENTIFY (which replays GUILD_CREATE); a RESUME does not replay it, so
+	// recovery there is via the staleness sweep or a manual RequestGuildMembers.
+	if c.ctx.Err() != nil {
+		c.s.log.Info(c.ctx, "drop guild member backfill: connection closed", slog.F("guild", guild))
+		return
+	}
 	select {
 	case c.wch <- &Op{
 		Op: 8,
@@ -243,7 +254,7 @@ func (c *conn) requestGuildMembers(guild int64) {
 		},
 	}:
 	default:
-		c.s.log.Error(c.ctx, "write channel full")
+		c.s.log.Error(c.ctx, "write channel full", slog.F("guild", guild))
 	}
 
 }

--- a/internal/gatewayws/write.go
+++ b/internal/gatewayws/write.go
@@ -84,11 +84,17 @@ func (s *Session) writeOp(op *Op) error {
 	if err != nil {
 		return xerrors.Errorf("get writer: %w", err)
 	}
-	defer w.Close()
 
-	_, err = w.Write(raw)
-	if err != nil {
+	if _, err = w.Write(raw); err != nil {
+		w.Close()
 		return xerrors.Errorf("write payload: %w", err)
+	}
+
+	// Close flushes the final frame. Check its error rather than deferring it:
+	// nhooyr surfaces a black-holed/timed-out write here, and swallowing it would
+	// let writeOp return nil on a failed send so the writer never exits or cancels.
+	if err = w.Close(); err != nil {
+		return xerrors.Errorf("flush payload: %w", err)
 	}
 
 	return nil

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -94,7 +94,8 @@ func (s *Session) Status() string {
 	if c == nil {
 		return fmt.Sprintf("%v: <disconnected>", s.shardID)
 	}
-	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, c.curState, c.lastAck.Format(time.RFC3339))
+	curState, _, lastAck, _ := c.snapshot()
+	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, curState, lastAck.Format(time.RFC3339))
 }
 
 func (s *Session) LongLastAck(threshold time.Duration) bool {
@@ -103,8 +104,9 @@ func (s *Session) LongLastAck(threshold time.Duration) bool {
 		// no active connection => definitionally not acking
 		return true
 	}
+	_, _, lastAck, ready := c.snapshot()
 	cutoff := time.Now().Add(-threshold)
-	return c.lastAck.Before(cutoff) && c.ready.Before(cutoff)
+	return lastAck.Before(cutoff) && ready.Before(cutoff)
 }
 
 func (c *conn) cleanupBuffer() {
@@ -261,7 +263,7 @@ func (s *Session) Open(ctx context.Context, token string) error {
 func (c *conn) run(parent context.Context) error {
 	defer c.authed.Store(false)
 
-	c.curState = "begin"
+	c.setState("begin")
 
 	c.s.log.Info(parent, "encoding", slog.F("name", c.s.enc.Name()))
 
@@ -295,7 +297,7 @@ func (c *conn) run(parent context.Context) error {
 	c.zr = r
 	defer r.Close()
 
-	c.curState = "connecting"
+	c.setState("connecting")
 	ws, _, err := websocket.Dial(c.ctx, c.GatewayURL(), nil)
 	if err != nil {
 		return xerrors.Errorf("dial gateway: %w", err)
@@ -303,7 +305,7 @@ func (c *conn) run(parent context.Context) error {
 	c.wsConn = ws
 	c.wsConn.SetReadLimit(512 << 20)
 
-	c.curState = "read hello"
+	c.setState("read hello")
 	err = c.readHello()
 	if err != nil {
 		return xerrors.Errorf("handle hello message: %w", err)
@@ -328,7 +330,8 @@ func (c *conn) run(parent context.Context) error {
 	defer c.s.persistShardInfo()
 
 	for {
-		c.s.log.Debug(c.ctx, "received event", slog.F("last_ack", c.lastAck), slog.F("last_hb", c.lastHB), slog.F("seq", atomic.LoadInt64(&c.s.seq)))
+		_, lastHB, lastAck, _ := c.snapshot()
+		c.s.log.Debug(c.ctx, "received event", slog.F("last_ack", lastAck), slog.F("last_hb", lastHB), slog.F("seq", atomic.LoadInt64(&c.s.seq)))
 
 		ev, err := c.readAndDecodeEvent()
 		if err != nil {
@@ -340,7 +343,7 @@ func (c *conn) run(parent context.Context) error {
 		}
 		c.s.log.Debug(c.ctx, "decoded event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 
-		c.curState = "handle internal event " + ev.T
+		c.setState("handle internal event " + ev.T)
 		c.s.log.Debug(c.ctx, "handling internal event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		var handled bool
 		if handled, err = c.handleInternalEvent(ev); handled {
@@ -350,7 +353,7 @@ func (c *conn) run(parent context.Context) error {
 			continue
 		}
 
-		c.curState = "handle state event " + ev.T
+		c.setState("handle state event " + ev.T)
 		c.s.log.Debug(c.ctx, "handling state event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		// parent ctx: in-flight state/DB work must NOT be aborted by a disconnect.
 		evtPayload, err := c.s.state.HandleEvent(parent, ev)
@@ -359,20 +362,20 @@ func (c *conn) run(parent context.Context) error {
 			continue
 		}
 
-		c.curState = "push event to redis"
+		c.setState("push event to redis")
 		c.s.log.Debug(c.ctx, "pushing event to redis", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		c.pushEventToRedis(ev)
 
 		// request guild members on GUILD_CREATE, gated by the backfill marker
 		if c.s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
-			c.curState = "maybe request guild members"
+			c.setState("maybe request guild members")
 			// parent ctx: same rationale as HandleEvent above.
 			c.maybeRequestGuildMembers(parent, evtPayload)
 		}
 
 	}
 
-	c.curState = "close"
+	c.setState("close")
 	_ = ws.Close(4000, "")
 	c.s.log.Info(c.ctx, "closed")
 	return err
@@ -412,7 +415,7 @@ func (c *conn) handleInternalEvent(ev *discord.Event) (bool, error) {
 	case 6:
 		c.s.log.Info(c.ctx, "resumed")
 		c.authed.Store(true)
-		c.ready = time.Now()
+		c.markReady(time.Now())
 
 		return true, nil
 
@@ -441,7 +444,7 @@ func (c *conn) handleInternalEvent(ev *discord.Event) (bool, error) {
 
 	// HEARTBEAT_ACK
 	case 11:
-		c.lastAck = time.Now()
+		c.markAck(time.Now())
 		return true, nil
 	}
 
@@ -489,7 +492,7 @@ func (c *conn) handleInternalEvent(ev *discord.Event) (bool, error) {
 			slog.F("guild_count", len(c.s.guilds)))
 		c.s.persistShardInfo()
 		c.authed.Store(true)
-		c.ready = time.Now()
+		c.markReady(time.Now())
 
 		go func() {
 			totalWaitTime := c.s.calcIdentifyWait()
@@ -504,7 +507,7 @@ func (c *conn) handleInternalEvent(ev *discord.Event) (bool, error) {
 	case "RESUMED":
 		c.s.log.Info(c.ctx, "resumed")
 		c.authed.Store(true)
-		c.ready = time.Now()
+		c.markReady(time.Now())
 
 		return true, nil
 	}
@@ -551,7 +554,7 @@ func (s *Session) RequestGuildMembers(guildID int64) {
 }
 
 func (c *conn) readAndDecodeEvent() (*discord.Event, error) {
-	c.curState = "read message"
+	c.setState("read message")
 	c.buf = c.s.bufferPool.Get().(*bytes.Buffer)
 	defer c.cleanupBuffer()
 
@@ -572,7 +575,7 @@ func (c *conn) readAndDecodeEvent() (*discord.Event, error) {
 		return nil, xerrors.Errorf("read message: %w", err)
 	}
 
-	c.curState = "decode event"
+	c.setState("decode event")
 	var ev *discord.Event
 	ev, err = c.s.enc.DecodeT(c.buf.Bytes())
 	if err != nil {

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"sync"
@@ -35,10 +34,12 @@ const (
 
 var skipMemberRequest = os.Getenv("SKIP_MEMBER_REQUEST") == "true"
 
+// Session is the durable, reused-across-reconnects identity of a shard. It owns
+// shared dependencies and the resume tuple, but NOT the live connection: each
+// Open builds a fresh conn (see conn.go) and publishes it to cur so management
+// calls (Cancel/ForceIdentify/RequestGuildMembers/Status/LongLastAck) reach it.
 type Session struct {
-	ctx    context.Context
-	cancel func()
-	wg     *sync.WaitGroup
+	wg *sync.WaitGroup
 
 	name string
 	log  slog.Logger
@@ -48,11 +49,10 @@ type Session struct {
 	shardID    int
 	shardCount int
 
-	authed    bool
 	seq       int64
 	sessID    string
 	resumeURL string
-	last      int64
+	last      int64 // event-rate baseline; accessed atomically (logTotalEvents goroutine)
 
 	// forceIdentify is set (atomically) by ForceIdentify from any goroutine to
 	// request that the next Open discard the resume tuple and IDENTIFY. It is
@@ -60,32 +60,21 @@ type Session struct {
 	// are only ever mutated there, never from the caller of ForceIdentify.
 	forceIdentify int32
 
-	wsConn *websocket.Conn
-	zr     io.ReadCloser
-
-	interval time.Duration
-	trace    string
-
-	rl     *rate.Limiter
-	wch    chan *Op
-	prioch chan *Op
-
-	lastHB       time.Time
-	lastAck      time.Time
-	ready        time.Time
 	lastIdentify time.Time
 
+	rl *rate.Limiter
+
+	// guilds/backfilled are mutated and read only on the read-loop goroutine
+	// (READY repopulates them, GUILD_CREATE reads them) and deliberately survive
+	// a RESUME, so the backfill-skip optimization keeps working across resumes.
+	// They stay on Session for that reason, not on the per-Open conn.
 	guilds     map[int64]struct{}
 	backfilled map[int64]struct{}
-	curState   string
 
 	bufferPool *sync.Pool
-	buf        *bytes.Buffer
 	enc        discord.Encoding
 
-	etcd       *clientv3.Client
-	etcdSess   *concurrency.Session
-	identifyMu *concurrency.Mutex
+	etcd *clientv3.Client
 
 	state   *handler.Client
 	stateDB state.DB
@@ -94,34 +83,47 @@ type Session struct {
 	whitelistedEvents map[string]map[string]struct{}
 
 	hasGuildMembersIntent bool
+
+	// cur is the current connection, published by Open and cleared on return.
+	// nil before the first Open and briefly between reconnects.
+	cur atomic.Pointer[conn]
 }
 
 func (s *Session) Status() string {
-	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, s.curState, s.lastAck.Format(time.RFC3339))
+	c := s.cur.Load()
+	if c == nil {
+		return fmt.Sprintf("%v: <disconnected>", s.shardID)
+	}
+	return fmt.Sprintf("%v: %s [LastAck: %v]", s.shardID, c.curState, c.lastAck.Format(time.RFC3339))
 }
 
 func (s *Session) LongLastAck(threshold time.Duration) bool {
+	c := s.cur.Load()
+	if c == nil {
+		// no active connection => definitionally not acking
+		return true
+	}
 	cutoff := time.Now().Add(-threshold)
-	return s.lastAck.Before(cutoff) && s.ready.Before(cutoff)
+	return c.lastAck.Before(cutoff) && c.ready.Before(cutoff)
 }
 
-func (s *Session) cleanupBuffer() {
-	if s.buf != nil {
-		if s.buf.Cap() < (1 << 24) {
-			s.buf.Reset()
-			s.bufferPool.Put(s.buf)
+func (c *conn) cleanupBuffer() {
+	if c.buf != nil {
+		if c.buf.Cap() < (1 << 24) {
+			c.buf.Reset()
+			c.s.bufferPool.Put(c.buf)
 		} else {
-			s.log.Debug(s.ctx, "buffer evicted", slog.F("size", s.buf.Cap()))
+			c.s.log.Debug(c.ctx, "buffer evicted", slog.F("size", c.buf.Cap()))
 		}
 	}
-	s.buf = nil
+	c.buf = nil
 }
 
-func (s *Session) GatewayURL() string {
-	wsOpts := "?v=10&encoding=" + s.enc.Name() + "&compress=zlib-stream"
+func (c *conn) GatewayURL() string {
+	wsOpts := "?v=10&encoding=" + c.s.enc.Name() + "&compress=zlib-stream"
 
-	if s.resumeURL != "" && s.sessID != "" {
-		return s.resumeURL + wsOpts
+	if c.s.resumeURL != "" && c.s.sessID != "" {
+		return c.s.resumeURL + wsOpts
 	}
 
 	return "wss://gateway.discord.gg/" + wsOpts
@@ -144,7 +146,6 @@ type SessionConfig struct {
 
 func NewSession(cfg *SessionConfig) (*Session, error) {
 	sess := &Session{
-		ctx:        context.Background(),
 		name:       cfg.Name,
 		wg:         cfg.WorkGroup,
 		log:        cfg.Logger.With(slog.F("name", cfg.Name), slog.F("shard", cfg.ShardID)),
@@ -153,10 +154,7 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 		shardCount: cfg.ShardCount,
 		intents:    cfg.Intents,
 
-		// start with a 1kb buffer
-		rl:     rate.NewLimiter(1.75, 2),
-		wch:    make(chan *Op, 2000),
-		prioch: make(chan *Op),
+		rl: rate.NewLimiter(1.75, 2),
 
 		etcd: cfg.Etcd,
 
@@ -194,16 +192,16 @@ func (s *Session) calcIdentifyWait() time.Duration {
 	return totalWaitTime
 }
 
-func (s *Session) initEtcd() error {
-	timeoutDuration := s.calcIdentifyWait() + TimeoutAllowance
+func (c *conn) initEtcd() error {
+	timeoutDuration := c.s.calcIdentifyWait() + TimeoutAllowance
 
-	sess, err := concurrency.NewSession(s.etcd, concurrency.WithContext(s.ctx), concurrency.WithTTL(int(timeoutDuration.Seconds())))
+	sess, err := concurrency.NewSession(c.s.etcd, concurrency.WithContext(c.ctx), concurrency.WithTTL(int(timeoutDuration.Seconds())))
 	if err != nil {
 		return xerrors.Errorf("get etcd session: %w", err)
 	}
 
-	s.etcdSess = sess
-	s.identifyMu = concurrency.NewMutex(sess, IdentifyMutexRootName+strconv.Itoa(s.shardID%16))
+	c.etcdSess = sess
+	c.identifyMu = concurrency.NewMutex(sess, IdentifyMutexRootName+strconv.Itoa(c.s.shardID%16))
 	return nil
 }
 
@@ -218,7 +216,8 @@ func (s *Session) shouldResume() bool {
 // the read-loop goroutine via applyForceIdentify, so sessID/resumeURL are never
 // written concurrently. persistShardInfo is flag-aware, so the moment the flag
 // is set the cleared tuple is what gets persisted — a crash before reconnect
-// cannot leave a resumable row behind.
+// cannot leave a resumable row behind. If no connection is active the flag still
+// persists and the next Open's applyForceIdentify consumes it.
 func (s *Session) ForceIdentify() {
 	atomic.StoreInt32(&s.forceIdentify, 1)
 	s.Cancel()
@@ -226,12 +225,12 @@ func (s *Session) ForceIdentify() {
 
 // applyForceIdentify clears the resume tuple if a force-identify is pending.
 // It must run on the read-loop goroutine (it mutates sessID/resumeURL) and is
-// called at the top of Open before the resume decision.
+// called at the top of run before the resume decision.
 func (s *Session) applyForceIdentify() {
 	if atomic.SwapInt32(&s.forceIdentify, 0) == 0 {
 		return
 	}
-	s.log.Info(s.ctx, "force identify requested, discarding resume state", slog.F("shard", s.shardID))
+	s.log.Info(context.Background(), "force identify requested, discarding resume state", slog.F("shard", s.shardID))
 	atomic.StoreInt64(&s.seq, 0)
 	s.sessID = ""
 	s.resumeURL = ""
@@ -242,196 +241,199 @@ func (s *Session) Open(ctx context.Context, token string) error {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
+	cctx, cancel := context.WithCancel(ctx)
+
+	c := s.newConn(cctx, cancel)
+	s.cur.Store(c)
+	// Cancel the connection's goroutines BEFORE retracting it from cur, so a
+	// concurrent Cancel/ForceIdentify never sees a nil cur while this
+	// connection's context is still live.
 	defer func() {
-		s.authed = false
+		cancel()
+		s.cur.Store(nil)
 	}()
 
-	s.curState = "begin"
-	s.ctx, s.cancel = context.WithCancel(ctx)
-	defer s.cancel()
+	// parent ctx is threaded into run so state-handling work survives a
+	// disconnect (see run); c.ctx is the connection-scoped context.
+	return c.run(ctx)
+}
 
-	s.log.Info(ctx, "encoding", slog.F("name", s.enc.Name()))
+func (c *conn) run(parent context.Context) error {
+	defer c.authed.Store(false)
 
-	s.resetHeartbeat()
+	c.curState = "begin"
+
+	c.s.log.Info(parent, "encoding", slog.F("name", c.s.enc.Name()))
 
 	// Consume any pending force-identify before deciding whether to resume, so a
 	// forced shard discards its resume tuple and IDENTIFYs this connect.
-	s.applyForceIdentify()
+	c.s.applyForceIdentify()
 
 	var err error
-	err = s.initEtcd()
+	err = c.initEtcd()
 	if err != nil {
 		return err
 	}
 
 	// only acquire the identify lock if we know we won't send a resume
-	if !s.shouldResume() {
-		s.log.Debug(s.ctx, "acquiring lock, no ability to resume")
-		err = s.acquireIdentifyLock()
+	if !c.s.shouldResume() {
+		c.s.log.Debug(c.ctx, "acquiring lock, no ability to resume")
+		err = c.acquireIdentifyLock()
 		if err != nil {
 			return xerrors.Errorf("grab identify lock: %w", err)
 		}
-		s.log.Debug(s.ctx, "lock acquired")
+		c.s.log.Debug(c.ctx, "lock acquired")
 
 	} else {
-		s.log.Debug(s.ctx, "skipping lock, attempting resume", slog.F("sess", s.sessID), slog.F("seq", atomic.LoadInt64(&s.seq)))
+		c.s.log.Debug(c.ctx, "skipping lock, attempting resume", slog.F("sess", c.s.sessID), slog.F("seq", atomic.LoadInt64(&c.s.seq)))
 	}
 
 	r, err := czlib.NewReader(bytes.NewReader(nil))
 	if err != nil {
 		return xerrors.Errorf("initialize zlib: %w", err)
 	}
-	s.zr = r
+	c.zr = r
 	defer r.Close()
 
-	s.curState = "connecting"
-	c, _, err := websocket.Dial(s.ctx, s.GatewayURL(), nil)
+	c.curState = "connecting"
+	ws, _, err := websocket.Dial(c.ctx, c.GatewayURL(), nil)
 	if err != nil {
 		return xerrors.Errorf("dial gateway: %w", err)
 	}
-	s.wsConn = c
-	s.wsConn.SetReadLimit(512 << 20)
+	c.wsConn = ws
+	c.wsConn.SetReadLimit(512 << 20)
 
-	s.curState = "read hello"
-	err = s.readHello()
+	c.curState = "read hello"
+	err = c.readHello()
 	if err != nil {
 		return xerrors.Errorf("handle hello message: %w", err)
 	}
 
-	// On a fresh session (identify, not resume) discard any ops queued on the
-	// previous connection so we don't replay a pre-identify backlog. This must
-	// happen BEFORE go s.writer(), because writer() captures wch/prioch into
-	// locals — swapping the channels after it starts orphans the writer from all
-	// new sends (heartbeats wedge, guild-member requests are silently dropped).
-	if !s.shouldResume() && len(s.wch)+len(s.prioch) > 0 {
-		s.wch = make(chan *Op, 2000)
-		s.prioch = make(chan *Op)
-	}
-
-	go s.writer()
-	if s.shouldResume() {
-		s.log.Info(s.ctx, "sending resume")
-		s.writeResume()
+	go c.writer()
+	if c.s.shouldResume() {
+		c.s.log.Info(c.ctx, "sending resume")
+		c.writeResume()
 	} else {
-		s.last = 0
-		s.log.Info(s.ctx, "sending identify")
-		s.writeIdentify()
-		s.lastIdentify = time.Now()
+		atomic.StoreInt64(&c.s.last, 0)
+		c.s.log.Info(c.ctx, "sending identify")
+		c.writeIdentify()
+		c.s.lastIdentify = time.Now()
 	}
 
-	go s.sendHeartbeats()
-	go s.logTotalEvents()
-	// go s.rotateStatuses()
+	go c.sendHeartbeats()
+	go c.logTotalEvents()
+	// go c.rotateStatuses()
 
-	s.log.Info(s.ctx, "websocket connected, waiting for events")
-	defer s.persistShardInfo()
+	c.s.log.Info(c.ctx, "websocket connected, waiting for events")
+	defer c.s.persistShardInfo()
 
 	for {
-		s.log.Debug(s.ctx, "received event", slog.F("last_ack", s.lastAck), slog.F("last_hb", s.lastHB), slog.F("seq", atomic.LoadInt64(&s.seq)))
+		c.s.log.Debug(c.ctx, "received event", slog.F("last_ack", c.lastAck), slog.F("last_hb", c.lastHB), slog.F("seq", atomic.LoadInt64(&c.s.seq)))
 
-		ev, err := s.readAndDecodeEvent()
+		ev, err := c.readAndDecodeEvent()
 		if err != nil {
-			s.log.Error(ctx, "read and decode event", slog.Error(err))
+			c.s.log.Error(c.ctx, "read and decode event", slog.Error(err))
 			break
 		}
 		if ev.S != 0 {
-			atomic.StoreInt64(&s.seq, ev.S)
+			atomic.StoreInt64(&c.s.seq, ev.S)
 		}
-		s.log.Debug(s.ctx, "decoded event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
+		c.s.log.Debug(c.ctx, "decoded event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 
-		s.curState = "handle internal event " + ev.T
-		s.log.Debug(s.ctx, "handling internal event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
+		c.curState = "handle internal event " + ev.T
+		c.s.log.Debug(c.ctx, "handling internal event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
 		var handled bool
-		if handled, err = s.handleInternalEvent(ev); handled {
+		if handled, err = c.handleInternalEvent(ev); handled {
 			if err != nil {
 				break
 			}
 			continue
 		}
 
-		s.curState = "handle state event " + ev.T
-		s.log.Debug(s.ctx, "handling state event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
-		evtPayload, err := s.state.HandleEvent(ctx, ev)
+		c.curState = "handle state event " + ev.T
+		c.s.log.Debug(c.ctx, "handling state event", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
+		// parent ctx: in-flight state/DB work must NOT be aborted by a disconnect.
+		evtPayload, err := c.s.state.HandleEvent(parent, ev)
 		if err != nil {
-			s.log.Error(s.ctx, "handle state event", slog.Error(err))
+			c.s.log.Error(c.ctx, "handle state event", slog.Error(err))
 			continue
 		}
 
-		s.curState = "push event to redis"
-		s.log.Debug(s.ctx, "pushing event to redis", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
-		s.pushEventToRedis(ev)
+		c.curState = "push event to redis"
+		c.s.log.Debug(c.ctx, "pushing event to redis", slog.F("op", ev.Op), slog.F("type", ev.T), slog.F("seq", ev.S))
+		c.pushEventToRedis(ev)
 
 		// request guild members on GUILD_CREATE, gated by the backfill marker
-		if s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
-			s.curState = "maybe request guild members"
-			s.maybeRequestGuildMembers(ctx, evtPayload)
+		if c.s.shouldProcessMembers() && ev.T == "GUILD_CREATE" && evtPayload != nil && evtPayload.GuildID != 0 {
+			c.curState = "maybe request guild members"
+			// parent ctx: same rationale as HandleEvent above.
+			c.maybeRequestGuildMembers(parent, evtPayload)
 		}
 
 	}
 
-	s.curState = "close"
-	_ = c.Close(4000, "")
-	s.log.Info(s.ctx, "closed")
+	c.curState = "close"
+	_ = ws.Close(4000, "")
+	c.s.log.Info(c.ctx, "closed")
 	return err
 }
 
-func (s *Session) pushEventToRedis(ev *discord.Event) {
+func (c *conn) pushEventToRedis(ev *discord.Event) {
 	if ev.T == "GUILD_MEMBER_CHUNK" {
 		return
 	}
 	push := func(addr string, rc *redis.Client) {
-		if whitelist, exists := s.whitelistedEvents[addr]; exists {
-			s.log.Debug(s.ctx, "checking whitelist", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
+		if whitelist, exists := c.s.whitelistedEvents[addr]; exists {
+			c.s.log.Debug(c.ctx, "checking whitelist", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
 			if _, ok := whitelist[ev.T]; !ok {
-				s.log.Debug(s.ctx, "not whitelisted", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
+				c.s.log.Debug(c.ctx, "not whitelisted", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
 				return
 			}
 		}
 
-		s.log.Debug(s.ctx, "pushing event to redis", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
-		if err := rc.RPush(s.ctx, "gateway:events:"+ev.T, ev.D).Err(); err != nil {
-			s.log.Error(s.ctx, "push event to redis", slog.Error(err), slog.F("event_type", ev.T), slog.F("redis_addr", addr))
+		c.s.log.Debug(c.ctx, "pushing event to redis", slog.F("event_type", ev.T), slog.F("redis_addr", addr))
+		if err := rc.RPush(c.ctx, "gateway:events:"+ev.T, ev.D).Err(); err != nil {
+			c.s.log.Error(c.ctx, "push event to redis", slog.Error(err), slog.F("event_type", ev.T), slog.F("redis_addr", addr))
 		}
 	}
 
-	for _, rc := range s.rc {
+	for _, rc := range c.s.rc {
 		push(rc.Options().Addr, rc)
 	}
 }
 
-func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
+func (c *conn) handleInternalEvent(ev *discord.Event) (bool, error) {
 	switch ev.Op {
 	case 1:
-		s.writeHeartbeat()
+		c.writeHeartbeat()
 		return true, nil
 
 	// RESUME
 	case 6:
-		s.log.Info(s.ctx, "resumed")
-		s.authed = true
-		s.ready = time.Now()
+		c.s.log.Info(c.ctx, "resumed")
+		c.authed.Store(true)
+		c.ready = time.Now()
 
 		return true, nil
 
 	// RECONNECT
 	case 7:
-		s.log.Info(s.ctx, "reconnect requested")
+		c.s.log.Info(c.ctx, "reconnect requested")
 
 		return true, xerrors.New("reconnect")
 
 	// INVALID_SESSION
 	case 9:
-		s.log.Info(s.ctx, "invalid session, reconnecting")
-		s.sessID = ""
-		atomic.StoreInt64(&s.seq, 0)
-		s.resumeURL = ""
-		s.persistShardInfo()
-		s.wch = make(chan *Op, 2000)
+		c.s.log.Info(c.ctx, "invalid session, reconnecting")
+		c.s.sessID = ""
+		atomic.StoreInt64(&c.s.seq, 0)
+		c.s.resumeURL = ""
+		c.s.persistShardInfo()
 
-		if s.identifyMu.IsOwner().Result == etcdserverpb.Compare_EQUAL {
-			err := s.releaseIdentifyLock()
+		if c.identifyMu.IsOwner().Result == etcdserverpb.Compare_EQUAL {
+			err := c.releaseIdentifyLock()
 			if err != nil {
-				s.log.Error(s.ctx, "release held identify lock after invalid session", slog.Error(err))
+				c.s.log.Error(c.ctx, "release held identify lock after invalid session", slog.Error(err))
 			}
 		}
 
@@ -439,20 +441,20 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 
 	// HEARTBEAT_ACK
 	case 11:
-		s.lastAck = time.Now()
+		c.lastAck = time.Now()
 		return true, nil
 	}
 
 	switch ev.T {
 	case "READY":
-		s.guilds = map[int64]struct{}{}
-		guilds, _, sess, resumeURL, err := s.enc.DecodeReady(ev.D)
+		c.s.guilds = map[int64]struct{}{}
+		guilds, _, sess, resumeURL, err := c.s.enc.DecodeReady(ev.D)
 		if err != nil {
 			return true, xerrors.Errorf("decode ready: %w", err)
 		}
 
 		for i := range guilds {
-			s.guilds[i] = struct{}{}
+			c.s.guilds[i] = struct{}{}
 		}
 
 		// No-expiry skip (reconnect-storm speed is the priority): skip RGM for any
@@ -468,42 +470,41 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 		// unclean PG restart (forcing a cold re-backfill). An optional Phase 3b
 		// background sweep can bound it further if staleness ever becomes a real
 		// problem; it is not required for this skip to be correct.
-		s.backfilled = map[int64]struct{}{}
-		ids := make([]int64, 0, len(s.guilds))
-		for id := range s.guilds {
+		c.s.backfilled = map[int64]struct{}{}
+		ids := make([]int64, 0, len(c.s.guilds))
+		for id := range c.s.guilds {
 			ids = append(ids, id)
 		}
-		if times, terr := s.stateDB.GetGuildBackfillTimes(s.ctx, ids); terr != nil {
-			s.log.Error(s.ctx, "preload guild backfill times", slog.Error(terr))
+		if times, terr := c.s.stateDB.GetGuildBackfillTimes(c.ctx, ids); terr != nil {
+			c.s.log.Error(c.ctx, "preload guild backfill times", slog.Error(terr))
 		} else {
 			for id := range times {
-				s.backfilled[id] = struct{}{}
+				c.s.backfilled[id] = struct{}{}
 			}
 		}
 
-		s.sessID = sess
-		s.resumeURL = resumeURL
-		s.log.Info(s.ctx, "ready", slog.F("sess", sess), slog.F("resume_gateway_url", resumeURL),
-			slog.F("guild_count", len(s.guilds)))
-		s.persistShardInfo()
-		s.authed = true
-		s.ready = time.Now()
+		c.s.sessID = sess
+		c.s.resumeURL = resumeURL
+		c.s.log.Info(c.ctx, "ready", slog.F("sess", sess), slog.F("resume_gateway_url", resumeURL),
+			slog.F("guild_count", len(c.s.guilds)))
+		c.s.persistShardInfo()
+		c.authed.Store(true)
+		c.ready = time.Now()
 
 		go func() {
-			totalWaitTime := s.calcIdentifyWait()
+			totalWaitTime := c.s.calcIdentifyWait()
 			time.Sleep(totalWaitTime)
-			err = s.releaseIdentifyLock()
-			if err != nil {
-				s.log.Error(s.ctx, "release identify lock after ready", slog.Error(err))
+			if err := c.releaseIdentifyLock(); err != nil {
+				c.s.log.Error(c.ctx, "release identify lock after ready", slog.Error(err))
 			}
 		}()
 
 		return true, nil
 
 	case "RESUMED":
-		s.log.Info(s.ctx, "resumed")
-		s.authed = true
-		s.ready = time.Now()
+		c.s.log.Info(c.ctx, "resumed")
+		c.authed.Store(true)
+		c.ready = time.Now()
 
 		return true, nil
 	}
@@ -511,11 +512,11 @@ func (s *Session) handleInternalEvent(ev *discord.Event) (bool, error) {
 	return false, nil
 }
 
-func (s *Session) acquireIdentifyLock() error {
-	timeoutLock, cancel := context.WithTimeout(s.ctx, time.Second*160)
+func (c *conn) acquireIdentifyLock() error {
+	timeoutLock, cancel := context.WithTimeout(c.ctx, time.Second*160)
 	defer cancel()
 
-	err := s.identifyMu.Lock(timeoutLock)
+	err := c.identifyMu.Lock(timeoutLock)
 	if err != nil {
 		return xerrors.Errorf("acquire identify lock: %w", err)
 	}
@@ -523,10 +524,10 @@ func (s *Session) acquireIdentifyLock() error {
 	return nil
 }
 
-func (s *Session) releaseIdentifyLock() error {
-	s.log.Info(s.ctx, "release identify lock", slog.F("key", s.identifyMu.Key()))
-	if s.identifyMu.Key() != "" {
-		err := s.identifyMu.Unlock(s.ctx)
+func (c *conn) releaseIdentifyLock() error {
+	c.s.log.Info(c.ctx, "release identify lock", slog.F("key", c.identifyMu.Key()))
+	if c.identifyMu.Key() != "" {
+		err := c.identifyMu.Unlock(c.ctx)
 		if err != nil {
 			return xerrors.Errorf("release identify lock: %w", err)
 		}
@@ -535,19 +536,26 @@ func (s *Session) releaseIdentifyLock() error {
 }
 
 func (s *Session) Cancel() {
-	// cancel is nil until the first Open; a management call (Cancel /
-	// ForceIdentify) can land before the shard has connected, so guard it.
-	if s.cancel != nil {
-		s.cancel()
+	if c := s.cur.Load(); c != nil {
+		c.cancel()
 	}
 }
 
-func (s *Session) readAndDecodeEvent() (*discord.Event, error) {
-	s.curState = "read message"
-	s.buf = s.bufferPool.Get().(*bytes.Buffer)
-	defer s.cleanupBuffer()
+func (s *Session) RequestGuildMembers(guildID int64) {
+	c := s.cur.Load()
+	if c == nil {
+		s.log.Info(context.Background(), "drop members request: no active connection", slog.F("guild", guildID))
+		return
+	}
+	c.requestGuildMembersExternal(guildID)
+}
 
-	err := s.readMessage()
+func (c *conn) readAndDecodeEvent() (*discord.Event, error) {
+	c.curState = "read message"
+	c.buf = c.s.bufferPool.Get().(*bytes.Buffer)
+	defer c.cleanupBuffer()
+
+	err := c.readMessage()
 	if err != nil {
 		var werr websocket.CloseError
 		if xerrors.As(err, &werr) {
@@ -555,18 +563,18 @@ func (s *Session) readAndDecodeEvent() (*discord.Event, error) {
 			// valid session associated with a different
 			// token.
 			if werr.Code == 4006 {
-				atomic.StoreInt64(&s.seq, 0)
-				s.sessID = ""
-				s.resumeURL = ""
-				s.persistShardInfo()
+				atomic.StoreInt64(&c.s.seq, 0)
+				c.s.sessID = ""
+				c.s.resumeURL = ""
+				c.s.persistShardInfo()
 			}
 		}
 		return nil, xerrors.Errorf("read message: %w", err)
 	}
 
-	s.curState = "decode event"
+	c.curState = "decode event"
 	var ev *discord.Event
-	ev, err = s.enc.DecodeT(s.buf.Bytes())
+	ev, err = c.s.enc.DecodeT(c.buf.Bytes())
 	if err != nil {
 		return nil, xerrors.Errorf("decode event: %w", err)
 	}

--- a/internal/gatewayws/ws.go
+++ b/internal/gatewayws/ws.go
@@ -298,6 +298,16 @@ func (s *Session) Open(ctx context.Context, token string) error {
 		return xerrors.Errorf("handle hello message: %w", err)
 	}
 
+	// On a fresh session (identify, not resume) discard any ops queued on the
+	// previous connection so we don't replay a pre-identify backlog. This must
+	// happen BEFORE go s.writer(), because writer() captures wch/prioch into
+	// locals — swapping the channels after it starts orphans the writer from all
+	// new sends (heartbeats wedge, guild-member requests are silently dropped).
+	if !s.shouldResume() && len(s.wch)+len(s.prioch) > 0 {
+		s.wch = make(chan *Op, 2000)
+		s.prioch = make(chan *Op)
+	}
+
 	go s.writer()
 	if s.shouldResume() {
 		s.log.Info(s.ctx, "sending resume")
@@ -306,10 +316,6 @@ func (s *Session) Open(ctx context.Context, token string) error {
 		s.last = 0
 		s.log.Info(s.ctx, "sending identify")
 		s.writeIdentify()
-		if len(s.wch)+len(s.prioch) > 0 {
-			s.wch = make(chan *Op, 2000)
-			s.prioch = make(chan *Op)
-		}
 		s.lastIdentify = time.Now()
 	}
 


### PR DESCRIPTION
## Why

The WS-deadlock fixes (#…/`fix/ws-send-deadlock-on-writer-exit`) kept patching a recurring bug class — captured-channel orphaning, heartbeat reset loops, the `lastAck`/`curState` data race — that all stem from one root cause: a single mutable `Session` is **reused across every reconnect**, so `Open()` has to manually scrub connection state (`resetHeartbeat`, `wch`/`prioch` swaps, the INVALID_SESSION `wch` rebuild) and four goroutines mutate shared fields. This PR removes the surface instead of patching it.

> Stacks on `fix/ws-send-deadlock-on-writer-exit` (base), which isn't merged to `master` yet. Review/merge that first.

## What

Split `internal/gatewayws/Session` into:
- **`Session`** — durable identity, shared deps, resume tuple, and a `cur atomic.Pointer[conn]` that management RPCs route through.
- **`conn`** — built fresh per `Open()`, owns ctx/cancel, `wch`/`prioch`, the websocket, buffers, and heartbeat timing. Discarded when the connection dies.

A connection can't inherit stale channels or timestamps because they didn't exist a moment earlier — the orphaning deadlock and heartbeat reset loop become **structurally impossible**, and the three reconnect-reset hacks are deleted.

### Behavior-preserving, deliberately
- `guilds`/`backfilled` stay on `Session` (read-loop single-owner) so they **survive a RESUME** — keeps the backfill-skip optimization working across resumes.
- `run(parent ctx)` preserves the two-context split: `state.HandleEvent`/`maybeRequestGuildMembers` keep the **parent** ctx so in-flight DB work isn't aborted by a disconnect.
- `Open` cancels the connection **before** clearing `cur`.
- `last` is now atomic on `Session`.

### Synchronization fix (bonus)
`lastHB`/`lastAck`/`ready`/`curState` are now behind a `conn.mu` (set/mark/snapshot accessors); `authed` is an `atomic.Bool`. This closes the pre-existing `lastAck`/`curState` data race.

### Two blessed, documented behavior changes
1. `RequestGuildMembers` (gRPC) is **dropped + logged** when no connection is active (was best-effort buffered; the old durability only held on the resume path and was already broken by the identify-path swap this PR removes).
2. `Status()`/`LongLastAck()` report `<disconnected>`/`true` on a nil current connection.

## Verification
- `go build ./...`, `go vet ./...` clean
- `go test -race ./internal/gatewayws/ ./internal/manager/ ./gatewaypb/` — PASS (19 gatewayws tests, incl. new channel-independence, nil-`cur`, and concurrent-`Status` race tests)
- Frozen external API (`NewSession`, `Open`, `Cancel`, `ForceIdentify`, `RequestGuildMembers`, `Status`, `LongLastAck`) — signatures unchanged
- Independent codex review of the executed diff: **clean**, no must-fix defects

Plan: `docs/superpowers/plans/2026-06-23-conn-lifecycle-refactor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)