### PR TITLE
fix(state): stop CompleteGuildBackfill from deleting un-refreshed members

### DIFF
--- a/internal/state/db/statepsql/backfills.go
+++ b/internal/state/db/statepsql/backfills.go
@@ -24,40 +24,23 @@ DO UPDATE SET started_at = now()
 	return nil
 }
 
-// CompleteGuildBackfill removes members untouched since this backfill's
-// started_at (departed ghosts) and stamps backfilled_at, in one transaction.
+// CompleteGuildBackfill stamps backfilled_at to mark the guild's roster fetched.
+//
+// It deliberately does NOT prune members absent from the backfill. The previous
+// reconcile DELETE (members untouched since started_at) could not distinguish a
+// genuinely-departed member from one whose upsert was dropped by the async member
+// batcher (failed batches are logged, never retried) or that arrived via an
+// out-of-order / interrupted chunk stream — so a transient refresh gap became
+// permanent member loss (observed in prod: a manual RGM marked the backfill
+// complete while live members vanished from `members`). Stale rows are left to
+// self-heal instead: live GUILD_MEMBER_REMOVE events prune departures while
+// connected, and the UNLOGGED members table is reset wholesale on an unclean PG
+// restart. The bounded drift this leaves is the same drift the no-expiry backfill
+// skip already accepts.
 func (db *db) CompleteGuildBackfill(ctx context.Context, guild int64) error {
-	// Flush pending member upserts for this guild so members queued by
-	// SetGuildMembers are persisted (with a fresh last_updated) before the
-	// reconcile DELETE below. Otherwise a current member whose row still
-	// carries an old last_updated could be deleted here and only re-inserted
-	// by the batcher moments later — a window where a live member is absent.
-	if err := db.memberBatcher.FlushForShard(ctx, uint64(guild)); err != nil {
-		return xerrors.Errorf("flush member batcher: %w", err)
-	}
-
-	tx, err := db.sql.BeginTx(ctx, nil)
-	if err != nil {
-		return xerrors.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback()
-
-	const del = `
-DELETE FROM members
-WHERE guild_id = $1
-  AND last_updated < (SELECT started_at FROM guild_backfills WHERE guild_id = $1)
-`
-	if _, err := tx.ExecContext(ctx, del, guild); err != nil {
-		return xerrors.Errorf("reconcile delete: %w", err)
-	}
-
 	const upd = `UPDATE guild_backfills SET backfilled_at = now() WHERE guild_id = $1`
-	if _, err := tx.ExecContext(ctx, upd, guild); err != nil {
+	if _, err := db.sql.ExecContext(ctx, upd, guild); err != nil {
 		return xerrors.Errorf("stamp backfilled_at: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return xerrors.Errorf("commit: %w", err)
 	}
 	return nil
 }

--- a/internal/state/db/statepsql/backfills.go
+++ b/internal/state/db/statepsql/backfills.go
@@ -24,7 +24,8 @@ DO UPDATE SET started_at = now()
 	return nil
 }
 
-// CompleteGuildBackfill stamps backfilled_at to mark the guild's roster fetched.
+// CompleteGuildBackfill flushes this guild's queued member upserts, then stamps
+// backfilled_at to mark the roster fetched.
 //
 // It deliberately does NOT prune members absent from the backfill. The previous
 // reconcile DELETE (members untouched since started_at) could not distinguish a
@@ -32,12 +33,27 @@ DO UPDATE SET started_at = now()
 // batcher (failed batches are logged, never retried) or that arrived via an
 // out-of-order / interrupted chunk stream — so a transient refresh gap became
 // permanent member loss (observed in prod: a manual RGM marked the backfill
-// complete while live members vanished from `members`). Stale rows are left to
-// self-heal instead: live GUILD_MEMBER_REMOVE events prune departures while
+// complete while live members vanished from `members`). Extra/stale rows are left
+// to self-heal instead: live GUILD_MEMBER_REMOVE events prune departures while
 // connected, and the UNLOGGED members table is reset wholesale on an unclean PG
 // restart. The bounded drift this leaves is the same drift the no-expiry backfill
 // skip already accepts.
+//
+// The flush before the stamp is a durability barrier, not the old DELETE guard:
+// SetGuildMembers only enqueues the final chunk on the async batcher, so stamping
+// the marker first would let a gateway crash or a dropped batch (the batcher
+// never retries) leave members unwritten while ws.go preloads the marker and
+// skips future RGM for the guild — a gap that would NOT self-heal, since
+// GUILD_MEMBER_REMOVE only prunes departures and cannot re-add a missing member
+// (guild_backfills is UNLOGGED too, so a PG crash clears the marker alongside the
+// members, but a gateway crash does not). FlushForShard blocks until the queued
+// rows persist; if it errors we return without stamping, leaving backfilled_at
+// NULL so the next GUILD_CREATE re-issues RGM.
 func (db *db) CompleteGuildBackfill(ctx context.Context, guild int64) error {
+	if err := db.memberBatcher.FlushForShard(ctx, uint64(guild)); err != nil {
+		return xerrors.Errorf("flush member batcher: %w", err)
+	}
+
 	const upd = `UPDATE guild_backfills SET backfilled_at = now() WHERE guild_id = $1`
 	if _, err := db.sql.ExecContext(ctx, upd, guild); err != nil {
 		return xerrors.Errorf("stamp backfilled_at: %w", err)

--- a/internal/state/db/statepsql/backfills_test.go
+++ b/internal/state/db/statepsql/backfills_test.go
@@ -20,11 +20,11 @@ func newTestDB(t *testing.T) *db {
 }
 
 // seedMember inserts a members row, setting last_updated DB-side relative to
-// the Postgres clock (now() + the given interval). It must use the DB clock,
-// not Go's: started_at is stamped by now(), and the reconciliation delete
-// compares the two — seeding from the app clock would introduce exactly the
-// skew the design forbids. Rows use random IDs, so the INSERT never conflicts
-// (and the BEFORE UPDATE trigger never fires to clobber last_updated).
+// the Postgres clock (now() + the given interval). It uses the DB clock, not
+// Go's, so a row can be placed deterministically before or after a backfill's
+// started_at (also stamped by now()) without app/DB clock skew. Rows use random
+// IDs, so the INSERT never conflicts (and the BEFORE UPDATE trigger never fires
+// to clobber the seeded last_updated).
 func seedMember(t *testing.T, d *db, guild, user int64, interval string) {
 	_, err := d.sql.Exec(
 		`INSERT INTO members (guild_id, user_id, data, last_updated)
@@ -79,25 +79,37 @@ func TestGetGuildBackfillTimesExcludesIncomplete(t *testing.T) {
 	}
 }
 
-func TestCompleteReconciliationDelete(t *testing.T) {
+// CompleteGuildBackfill must NOT delete members. The reconcile DELETE was removed:
+// it could not tell a member genuinely absent from the roster apart from one whose
+// upsert was silently dropped by the async batcher (logged, never retried) or that
+// arrived via an out-of-order / incomplete chunk stream — so it turned a transient
+// refresh gap into permanent member loss. Observed in prod: a manual RGM marked the
+// backfill complete while live members vanished from `members`. Completion now only
+// stamps backfilled_at; stale rows self-heal on the next member event or backfill.
+func TestCompleteStampsMarkerWithoutDeleting(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()
 	guild := rand.Int63()
-	ghost := rand.Int63()
-	fresh := rand.Int63()
+	stale := rand.Int63() // last_updated before started_at (formerly a deleted "ghost")
+	fresh := rand.Int63() // last_updated after started_at
 
-	// ghost predates this backfill; fresh is updated during the drain.
 	assert.Success(t, "begin", d.BeginGuildBackfill(ctx, guild))
-	seedMember(t, d, guild, ghost, "-1 hour") // last_updated before started_at
-	seedMember(t, d, guild, fresh, "1 hour")  // last_updated after started_at
+	seedMember(t, d, guild, stale, "-1 hour")
+	seedMember(t, d, guild, fresh, "1 hour")
 
 	assert.Success(t, "complete", d.CompleteGuildBackfill(ctx, guild))
 
-	if memberExists(t, d, guild, ghost) {
-		t.Fatalf("ghost member (untouched since started_at) should be deleted")
+	if !memberExists(t, d, guild, stale) {
+		t.Fatalf("completion must not delete a member, even one untouched since started_at")
 	}
 	if !memberExists(t, d, guild, fresh) {
-		t.Fatalf("member updated during drain should survive")
+		t.Fatalf("completion must not delete a member updated during the drain")
+	}
+
+	times, err := d.GetGuildBackfillTimes(ctx, []int64{guild})
+	assert.Success(t, "get times", err)
+	if _, ok := times[guild]; !ok {
+		t.Fatalf("completion must stamp backfilled_at")
 	}
 }
 

--- a/internal/state/db/statepsql/backfills_test.go
+++ b/internal/state/db/statepsql/backfills_test.go
@@ -113,6 +113,33 @@ func TestCompleteStampsMarkerWithoutDeleting(t *testing.T) {
 	}
 }
 
+func TestCompleteFlushesQueuedMembers(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+	guild := rand.Int63()
+	user := rand.Int63()
+
+	assert.Success(t, "begin", d.BeginGuildBackfill(ctx, guild))
+
+	// SetGuildMembers only enqueues on the async batcher; the row is not durable
+	// until the batcher drains. CompleteGuildBackfill must flush that queue before
+	// stamping, so the member is guaranteed present the instant Complete returns
+	// (without the flush this races the batcher's flush interval).
+	assert.Success(t, "queue member",
+		d.SetGuildMembers(ctx, guild, map[int64][]byte{user: []byte(`{}`)}))
+	assert.Success(t, "complete", d.CompleteGuildBackfill(ctx, guild))
+
+	if !memberExists(t, d, guild, user) {
+		t.Fatalf("completion must flush queued member upserts before stamping the marker")
+	}
+
+	times, err := d.GetGuildBackfillTimes(ctx, []int64{guild})
+	assert.Success(t, "get times", err)
+	if _, ok := times[guild]; !ok {
+		t.Fatalf("completion must stamp backfilled_at")
+	}
+}
+
 func TestReconcileGuildMembers(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()

--- a/internal/state/db/statepsql/batcher.go
+++ b/internal/state/db/statepsql/batcher.go
@@ -2,6 +2,7 @@ package statepsql
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"cdr.dev/slog"
@@ -65,10 +66,13 @@ func (s *ShardedBatcher[T]) Send(ctx context.Context, ev T) error {
 
 // FlushForShard synchronously flushes every event currently queued for the
 // worker that owns routeKey, blocking until those rows are persisted. Callers
-// use it to close the window where a just-queued upsert has not yet been
-// written before a dependent read/delete on the same key (e.g. the backfill
-// ghost-reconciliation DELETE). It flushes only events whose Send has already
-// returned, so the caller must Send before calling this.
+// use it as a durability barrier — e.g. before stamping a backfill complete —
+// so a just-queued upsert is guaranteed written before a dependent action on
+// the same key. It also surfaces any error dropped by an earlier async
+// (ticker- or size-triggered) flush for that worker, so a transient
+// intermediate write failure cannot be silently stamped over. It flushes only
+// events whose Send has already returned, so the caller must Send before
+// calling this.
 func (s *ShardedBatcher[T]) FlushForShard(ctx context.Context, routeKey uint64) error {
 	req := make(chan error, 1)
 	fc := s.flushChans[routeKey%uint64(len(s.flushChans))]
@@ -121,6 +125,17 @@ func runBatcher[T BatchEvent](
 	inFlight := make(chan struct{}, 1)
 	batch := make(map[any]T)
 
+	// asyncErr latches the first error from an async (ticker- or size-triggered)
+	// flush so the next FlushForShard can surface it instead of silently
+	// returning nil. Without this, a transient write failure on an intermediate
+	// backfill flush is logged and dropped, and CompleteGuildBackfill stamps the
+	// guild complete over the missing members. Guarded by asyncMu because the
+	// spawned flush goroutine writes it while the batcher loop reads it.
+	var (
+		asyncMu  sync.Mutex
+		asyncErr error
+	)
+
 	flush := func() {
 		if len(batch) == 0 {
 			return
@@ -135,6 +150,11 @@ func runBatcher[T BatchEvent](
 			defer func() { <-inFlight }()
 			if err := process(ctx, events); err != nil {
 				logger.Error(ctx, "processing batch", slog.F("err", err))
+				asyncMu.Lock()
+				if asyncErr == nil {
+					asyncErr = err
+				}
+				asyncMu.Unlock()
 			}
 		}()
 	}
@@ -196,6 +216,15 @@ func runBatcher[T BatchEvent](
 				ferr = process(ctx, events)
 			}
 			<-inFlight
+			// Fold in (and clear) any error from an earlier async flush in this
+			// window. The inFlight barrier above guarantees that goroutine has
+			// finished, so asyncErr reflects its final result.
+			asyncMu.Lock()
+			if ferr == nil {
+				ferr = asyncErr
+			}
+			asyncErr = nil
+			asyncMu.Unlock()
 			req <- ferr
 		}
 	}

--- a/internal/state/db/statepsql/batcher.go
+++ b/internal/state/db/statepsql/batcher.go
@@ -46,12 +46,20 @@ type GuildEvent struct {
 func (e GuildEvent) RouteKey() uint64 { return uint64(e.GuildID) }
 func (e GuildEvent) DedupKey() any    { return e.GuildID }
 
+// flushRequest asks a worker to synchronously flush and report the result for a
+// specific route key. The route key is carried (not just the worker index) so
+// the worker can surface a dropped-flush error attributed to that exact key.
+type flushRequest struct {
+	routeKey uint64
+	reply    chan error
+}
+
 // ShardedBatcher fans events across N independent batch workers, routed by
 // RouteKey() % N. Events for the same guild cluster on one worker for better
 // batch locality; dedup within a batch uses DedupKey().
 type ShardedBatcher[T BatchEvent] struct {
 	chans      []chan T
-	flushChans []chan chan error
+	flushChans []chan flushRequest
 }
 
 func (s *ShardedBatcher[T]) Send(ctx context.Context, ev T) error {
@@ -68,13 +76,14 @@ func (s *ShardedBatcher[T]) Send(ctx context.Context, ev T) error {
 // worker that owns routeKey, blocking until those rows are persisted. Callers
 // use it as a durability barrier — e.g. before stamping a backfill complete —
 // so a just-queued upsert is guaranteed written before a dependent action on
-// the same key. It also surfaces any error dropped by an earlier async
-// (ticker- or size-triggered) flush for that worker, so a transient
-// intermediate write failure cannot be silently stamped over. It flushes only
-// events whose Send has already returned, so the caller must Send before
-// calling this.
+// the same key. It also surfaces (and clears) any error dropped by an earlier
+// async (ticker- or size-triggered) flush that included routeKey, so a
+// transient write failure cannot be silently stamped over. The error is
+// attributed to routeKey specifically, so a flush for one key never consumes
+// another key's failure even when they share a worker. It flushes only events
+// whose Send has already returned, so the caller must Send before calling this.
 func (s *ShardedBatcher[T]) FlushForShard(ctx context.Context, routeKey uint64) error {
-	req := make(chan error, 1)
+	req := flushRequest{routeKey: routeKey, reply: make(chan error, 1)}
 	fc := s.flushChans[routeKey%uint64(len(s.flushChans))]
 	select {
 	case fc <- req:
@@ -82,7 +91,7 @@ func (s *ShardedBatcher[T]) FlushForShard(ctx context.Context, routeKey uint64) 
 		return ctx.Err()
 	}
 	select {
-	case err := <-req:
+	case err := <-req.reply:
 		return err
 	case <-ctx.Done():
 		return ctx.Err()
@@ -101,10 +110,10 @@ func NewShardedBatcher[T BatchEvent](
 		shards = 1
 	}
 	chans := make([]chan T, shards)
-	flushChans := make([]chan chan error, shards)
+	flushChans := make([]chan flushRequest, shards)
 	for i := range chans {
 		chans[i] = make(chan T, 4000)
-		flushChans[i] = make(chan chan error)
+		flushChans[i] = make(chan flushRequest)
 		go runBatcher(ctx, chans[i], flushChans[i], maxBatchSize, flushInterval, process, logger)
 	}
 	return &ShardedBatcher[T]{chans: chans, flushChans: flushChans}
@@ -113,7 +122,7 @@ func NewShardedBatcher[T BatchEvent](
 func runBatcher[T BatchEvent](
 	ctx context.Context,
 	ch <-chan T,
-	flushReq <-chan chan error,
+	flushReq <-chan flushRequest,
 	maxBatchSize int,
 	flushInterval time.Duration,
 	process func(context.Context, []T) error,
@@ -125,16 +134,27 @@ func runBatcher[T BatchEvent](
 	inFlight := make(chan struct{}, 1)
 	batch := make(map[any]T)
 
-	// asyncErr latches the first error from an async (ticker- or size-triggered)
-	// flush so the next FlushForShard can surface it instead of silently
-	// returning nil. Without this, a transient write failure on an intermediate
-	// backfill flush is logged and dropped, and CompleteGuildBackfill stamps the
-	// guild complete over the missing members. Guarded by asyncMu because the
-	// spawned flush goroutine writes it while the batcher loop reads it.
+	// failed records the last dropped-flush error per route key. A batch spans
+	// many route keys (this worker owns every key with key%shards == this
+	// shard), and a failed flush drops all of them without retry, so the error
+	// must be attributed to each affected key rather than latched worker-wide.
+	// Otherwise the first FlushForShard for any key on this worker would consume
+	// and clear the failure, and a different key whose members were in the same
+	// dropped batch would then flush clean and stamp its backfill complete over
+	// the missing rows. Guarded by failedMu because the async flush goroutine
+	// writes it while the batcher loop reads it. FlushForShard clears a key on
+	// read; the entry is re-created if a later flush for that key fails again.
 	var (
-		asyncMu  sync.Mutex
-		asyncErr error
+		failedMu sync.Mutex
+		failed   = make(map[uint64]error)
 	)
+	markFailed := func(events []T, err error) {
+		failedMu.Lock()
+		for _, ev := range events {
+			failed[ev.RouteKey()] = err
+		}
+		failedMu.Unlock()
+	}
 
 	flush := func() {
 		if len(batch) == 0 {
@@ -150,11 +170,7 @@ func runBatcher[T BatchEvent](
 			defer func() { <-inFlight }()
 			if err := process(ctx, events); err != nil {
 				logger.Error(ctx, "processing batch", slog.F("err", err))
-				asyncMu.Lock()
-				if asyncErr == nil {
-					asyncErr = err
-				}
-				asyncMu.Unlock()
+				markFailed(events, err)
 			}
 		}()
 	}
@@ -213,19 +229,27 @@ func runBatcher[T BatchEvent](
 					events = append(events, ev)
 				}
 				batch = make(map[any]T)
-				ferr = process(ctx, events)
+				if ferr = process(ctx, events); ferr != nil {
+					// This synchronous batch also spans multiple route keys;
+					// on failure record every one so a key other than the
+					// caller's does not later flush clean over dropped rows.
+					markFailed(events, ferr)
+				}
 			}
 			<-inFlight
-			// Fold in (and clear) any error from an earlier async flush in this
-			// window. The inFlight barrier above guarantees that goroutine has
-			// finished, so asyncErr reflects its final result.
-			asyncMu.Lock()
-			if ferr == nil {
-				ferr = asyncErr
+			// Surface (and clear) a dropped-flush error for the caller's route
+			// key only — from this synchronous flush or an earlier async one for
+			// the same key. The inFlight barrier above guarantees any async
+			// goroutine has finished, so failed reflects its final result.
+			failedMu.Lock()
+			if e, bad := failed[req.routeKey]; bad {
+				delete(failed, req.routeKey)
+				if ferr == nil {
+					ferr = e
+				}
 			}
-			asyncErr = nil
-			asyncMu.Unlock()
-			req <- ferr
+			failedMu.Unlock()
+			req.reply <- ferr
 		}
 	}
 }

--- a/internal/state/db/statepsql/batcher.go
+++ b/internal/state/db/statepsql/batcher.go
@@ -98,6 +98,23 @@ func (s *ShardedBatcher[T]) FlushForShard(ctx context.Context, routeKey uint64) 
 	}
 }
 
+// BatcherOption configures optional ShardedBatcher behavior.
+type BatcherOption func(*batcherConfig)
+
+type batcherConfig struct {
+	trackFlushErrors bool
+}
+
+// WithFlushErrorTracking makes workers retain per-route-key errors from dropped
+// (async, or synchronous flushReq) flushes so a later FlushForShard for that key
+// surfaces them. Enable it only for batchers whose FlushForShard results are
+// consumed — i.e. the member batcher backing CompleteGuildBackfill. Without a
+// consumer the retained entries are never read and would accumulate for the life
+// of the process during a write outage, so it stays off by default.
+func WithFlushErrorTracking() BatcherOption {
+	return func(c *batcherConfig) { c.trackFlushErrors = true }
+}
+
 func NewShardedBatcher[T BatchEvent](
 	ctx context.Context,
 	shards int,
@@ -105,16 +122,21 @@ func NewShardedBatcher[T BatchEvent](
 	flushInterval time.Duration,
 	process func(context.Context, []T) error,
 	logger slog.Logger,
+	opts ...BatcherOption,
 ) *ShardedBatcher[T] {
 	if shards < 1 {
 		shards = 1
+	}
+	var cfg batcherConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	chans := make([]chan T, shards)
 	flushChans := make([]chan flushRequest, shards)
 	for i := range chans {
 		chans[i] = make(chan T, 4000)
 		flushChans[i] = make(chan flushRequest)
-		go runBatcher(ctx, chans[i], flushChans[i], maxBatchSize, flushInterval, process, logger)
+		go runBatcher(ctx, chans[i], flushChans[i], maxBatchSize, flushInterval, process, logger, cfg)
 	}
 	return &ShardedBatcher[T]{chans: chans, flushChans: flushChans}
 }
@@ -127,6 +149,7 @@ func runBatcher[T BatchEvent](
 	flushInterval time.Duration,
 	process func(context.Context, []T) error,
 	logger slog.Logger,
+	cfg batcherConfig,
 ) {
 	ticker := time.NewTicker(flushInterval)
 	defer ticker.Stop()
@@ -144,11 +167,16 @@ func runBatcher[T BatchEvent](
 	// the missing rows. Guarded by failedMu because the async flush goroutine
 	// writes it while the batcher loop reads it. FlushForShard clears a key on
 	// read; the entry is re-created if a later flush for that key fails again.
+	// Only populated when trackFlushErrors is set (batchers with a FlushForShard
+	// consumer); otherwise entries would never be read and would accumulate.
 	var (
 		failedMu sync.Mutex
 		failed   = make(map[uint64]error)
 	)
 	markFailed := func(events []T, err error) {
+		if !cfg.trackFlushErrors {
+			return
+		}
 		failedMu.Lock()
 		for _, ev := range events {
 			failed[ev.RouteKey()] = err

--- a/internal/state/db/statepsql/batcher_test.go
+++ b/internal/state/db/statepsql/batcher_test.go
@@ -130,19 +130,32 @@ func TestShardedBatcherFlushForShardSurfacesAsyncError(t *testing.T) {
 
 	wantErr := errors.New("batch write failed")
 	var calls atomic.Int64
+	flushed := make(chan struct{}, 1)
 	process := func(_ context.Context, _ []testEvent) error {
 		if calls.Add(1) == 1 {
-			return wantErr // the first (size-triggered) flush fails transiently
+			flushed <- struct{}{} // the size-triggered async flush ran...
+			return wantErr        // ...and failed transiently
 		}
 		return nil
 	}
 	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
 
-	// Two events hit maxBatchSize and trigger a flush whose error the worker
-	// logs and drops. FlushForShard must still surface it — otherwise
+	// Two events hit maxBatchSize and trigger an async flush whose error the
+	// worker logs and drops. FlushForShard must still surface it — otherwise
 	// CompleteGuildBackfill would stamp the guild complete over lost members.
 	_ = b.Send(ctx, testEvent{route: 1, dedup: 1})
 	_ = b.Send(ctx, testEvent{route: 1, dedup: 2})
+
+	// Wait until that size-triggered flush has actually run before flushing, so
+	// the batch is already drained and FlushForShard can only report the error
+	// via the async latch — not by re-flushing the events synchronously itself.
+	// Without this the flushReq could win the select race and pass even if the
+	// latch were broken.
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("size-triggered async flush never ran")
+	}
 
 	if err := b.FlushForShard(ctx, 1); err == nil {
 		t.Fatal("FlushForShard swallowed the dropped async flush error")

--- a/internal/state/db/statepsql/batcher_test.go
+++ b/internal/state/db/statepsql/batcher_test.go
@@ -2,7 +2,9 @@ package statepsql
 
 import (
 	"context"
+	"errors"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,6 +122,36 @@ func TestShardedBatcherFlushForShardIsSynchronous(t *testing.T) {
 		}
 	default:
 		t.Fatal("FlushForShard returned before the batch was processed")
+	}
+}
+
+func TestShardedBatcherFlushForShardSurfacesAsyncError(t *testing.T) {
+	ctx := t.Context()
+
+	wantErr := errors.New("batch write failed")
+	var calls atomic.Int64
+	process := func(_ context.Context, _ []testEvent) error {
+		if calls.Add(1) == 1 {
+			return wantErr // the first (size-triggered) flush fails transiently
+		}
+		return nil
+	}
+	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
+
+	// Two events hit maxBatchSize and trigger a flush whose error the worker
+	// logs and drops. FlushForShard must still surface it — otherwise
+	// CompleteGuildBackfill would stamp the guild complete over lost members.
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 1})
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 2})
+
+	if err := b.FlushForShard(ctx, 1); err == nil {
+		t.Fatal("FlushForShard swallowed the dropped async flush error")
+	}
+
+	// The latched error is cleared on read: a later successful flush is clean.
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 3})
+	if err := b.FlushForShard(ctx, 1); err != nil {
+		t.Fatalf("FlushForShard should be clean after the error was consumed, got %v", err)
 	}
 }
 

--- a/internal/state/db/statepsql/batcher_test.go
+++ b/internal/state/db/statepsql/batcher_test.go
@@ -161,10 +161,48 @@ func TestShardedBatcherFlushForShardSurfacesAsyncError(t *testing.T) {
 		t.Fatal("FlushForShard swallowed the dropped async flush error")
 	}
 
-	// The latched error is cleared on read: a later successful flush is clean.
+	// The recorded error is cleared on read: a later successful flush is clean.
 	_ = b.Send(ctx, testEvent{route: 1, dedup: 3})
 	if err := b.FlushForShard(ctx, 1); err != nil {
 		t.Fatalf("FlushForShard should be clean after the error was consumed, got %v", err)
+	}
+}
+
+func TestShardedBatcherFlushForShardErrorIsPerRouteKey(t *testing.T) {
+	ctx := t.Context()
+
+	wantErr := errors.New("batch write failed")
+	var calls atomic.Int64
+	flushed := make(chan struct{}, 1)
+	process := func(_ context.Context, _ []testEvent) error {
+		if calls.Add(1) == 1 {
+			flushed <- struct{}{} // route-1's size-triggered flush ran...
+			return wantErr        // ...and failed transiently
+		}
+		return nil
+	}
+	// Single worker so routes 1 and 2 share it (as ~all guilds share one of
+	// maxConns=4 workers in prod). maxBatchSize 2 so two route-1 events flush.
+	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
+
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 1})
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 2})
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("size-triggered async flush never ran")
+	}
+
+	// Route 2 shares the worker but was not in the failed batch. It must NOT
+	// consume route 1's dropped-flush error — otherwise route 1 would later
+	// flush clean and stamp its backfill complete over its missing members.
+	if err := b.FlushForShard(ctx, 2); err != nil {
+		t.Fatalf("route 2 must not see route 1's dropped async error, got %v", err)
+	}
+
+	// Route 1 must still surface its own dropped-flush error.
+	if err := b.FlushForShard(ctx, 1); err == nil {
+		t.Fatal("route 1's FlushForShard must surface its own dropped async error")
 	}
 }
 

--- a/internal/state/db/statepsql/batcher_test.go
+++ b/internal/state/db/statepsql/batcher_test.go
@@ -138,7 +138,7 @@ func TestShardedBatcherFlushForShardSurfacesAsyncError(t *testing.T) {
 		}
 		return nil
 	}
-	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
+	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr), WithFlushErrorTracking())
 
 	// Two events hit maxBatchSize and trigger an async flush whose error the
 	// worker logs and drops. FlushForShard must still surface it — otherwise
@@ -183,7 +183,7 @@ func TestShardedBatcherFlushForShardErrorIsPerRouteKey(t *testing.T) {
 	}
 	// Single worker so routes 1 and 2 share it (as ~all guilds share one of
 	// maxConns=4 workers in prod). maxBatchSize 2 so two route-1 events flush.
-	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
+	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr), WithFlushErrorTracking())
 
 	_ = b.Send(ctx, testEvent{route: 1, dedup: 1})
 	_ = b.Send(ctx, testEvent{route: 1, dedup: 2})
@@ -203,6 +203,37 @@ func TestShardedBatcherFlushForShardErrorIsPerRouteKey(t *testing.T) {
 	// Route 1 must still surface its own dropped-flush error.
 	if err := b.FlushForShard(ctx, 1); err == nil {
 		t.Fatal("route 1's FlushForShard must surface its own dropped async error")
+	}
+}
+
+func TestShardedBatcherFlushErrorTrackingOffByDefault(t *testing.T) {
+	ctx := t.Context()
+
+	wantErr := errors.New("batch write failed")
+	var calls atomic.Int64
+	flushed := make(chan struct{}, 1)
+	process := func(_ context.Context, _ []testEvent) error {
+		if calls.Add(1) == 1 {
+			flushed <- struct{}{}
+			return wantErr
+		}
+		return nil
+	}
+	// No WithFlushErrorTracking (the presence/guild batchers, which never call
+	// FlushForShard): a dropped async flush must not be retained, else entries
+	// would accumulate for the life of the process with nothing to consume them.
+	b := NewShardedBatcher(ctx, 1, 2, 10*time.Second, process, sloghuman.Make(os.Stderr))
+
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 1})
+	_ = b.Send(ctx, testEvent{route: 1, dedup: 2})
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("size-triggered async flush never ran")
+	}
+
+	if err := b.FlushForShard(ctx, 1); err != nil {
+		t.Fatalf("without tracking, FlushForShard must not retain the dropped error, got %v", err)
 	}
 }
 

--- a/internal/state/db/statepsql/db.go
+++ b/internal/state/db/statepsql/db.go
@@ -46,8 +46,10 @@ func NewDB(ctx context.Context, addr string, logger slog.Logger) (state.DB, erro
 		return nil, xerrors.Errorf("ping postgres: %w", err)
 	}
 	dbInstance := &db{sql: sqlx, logger: logger}
+	// Only the member batcher's FlushForShard result is consumed (by
+	// CompleteGuildBackfill), so only it retains per-key flush errors.
 	dbInstance.memberBatcher = NewShardedBatcher(ctx, maxConns, 1000, 100*time.Millisecond,
-		dbInstance.processMemberBatch, logger)
+		dbInstance.processMemberBatch, logger, WithFlushErrorTracking())
 	dbInstance.presenceBatcher = NewShardedBatcher(ctx, maxConns, 1000, 100*time.Millisecond,
 		dbInstance.processPresenceBatch, logger)
 	dbInstance.guildBatcher = NewShardedBatcher(ctx, maxConns, 500, 100*time.Millisecond,


### PR DESCRIPTION
## Problem

Confirmed prod data-loss bug (2026-06-24). After a manual `RequestGuildMembers` (op-8 / `request-guild-members.sh`), guilds went unresponsive to message events. Root cause was **members deleted from the state DB**, so atlas/eventer could no longer dispatch for the guild.

`CompleteGuildBackfill`'s reconcile step ran `DELETE FROM members WHERE last_updated < started_at`, removing any member the backfill didn't refresh. Re-sent members are safe (the BEFORE UPDATE trigger bumps `last_updated` past `started_at`), but members whose async upsert never durably landed were permanently deleted. The member batcher (`batcher.go runBatcher`) logs and drops failed batches with no retry, and only the final `FlushForShard` surfaces errors — so a transient write gap became permanent member loss.

## Fix

Remove the reconcile `DELETE`; `CompleteGuildBackfill` no longer prunes members. No after-the-fact guard can distinguish an incomplete backfill from a genuinely small guild, so the delete is removed rather than guarded. Extra/stale rows self-heal via live `GUILD_MEMBER_REMOVE` and the UNLOGGED-table reset on unclean PG restart.

`FlushForShard` is **kept** (before the `backfilled_at` stamp) as a durability barrier — see follow-up `2401806`. `SetGuildMembers` only enqueues on the async batcher, so stamping without a flush would let a gateway crash or a dropped batch leave members unwritten while `ws.go` preloads the marker and skips future RGM — a gap that doesn't self-heal (`GUILD_MEMBER_REMOVE` prunes departures, not missing members; only a PG crash clears the UNLOGGED marker to force re-backfill). On flush error we return without stamping, so `backfilled_at` stays NULL and the next `GUILD_CREATE` re-issues RGM.

## Deployment status

The original image `tatsu/gateway:fb9e062-release` was deployed and recovery (re-fetch of ~2358 affected guilds via RGM) completed 2026-06-25. **The follow-up `2401806` (flush-before-stamp) is not yet in prod — this branch now diverges from the deployed image and needs a redeploy to reconcile.** The branch was cut off `fix/ws-send-deadlock-on-writer-exit` (now merged to master via #79/#81), so it is a clean diff against master.

## Files
- `internal/state/db/statepsql/backfills.go`
- `internal/state/db/statepsql/backfills_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)