### PR TITLE
fix(build): pin docker builds to linux/amd64 and assert arch before push

### DIFF
--- a/build-gateway.sh
+++ b/build-gateway.sh
@@ -10,9 +10,21 @@ if [[ $VERSION == *-dirty ]]; then
   VERSION+="-$(head -c 5 < /dev/urandom | base32)"
 fi
 
+# Cluster nodes are amd64, so always build for linux/amd64 — a plain
+# `docker build` on an Apple Silicon Mac produces an arm64 image that
+# crashloops on k8s with "exec format error" (see the 2026-08-05 whirlwind
+# staging incident, tatsuworks/whirlwind#56).
 # gateway_uri="gcr.io/tatsu-production/gateway:$VERSION"
 gateway_uri="6222o0k9.gra7.container-registry.ovh.net/tatsu/gateway:$VERSION"
-docker build -t "$gateway_uri" -f Dockerfile.gateway .
+docker build --platform linux/amd64 -t "$gateway_uri" -f Dockerfile.gateway .
+
+# Refuse to push an image with the wrong architecture.
+arch="$(docker image inspect "$gateway_uri" --format '{{.Architecture}}')"
+if [[ "$arch" != "amd64" ]]; then
+  echo "Built image architecture is '$arch', expected amd64 — not pushing." >&2
+  exit 1
+fi
+
 docker push "$gateway_uri"
 
 echo "New gateway image URI: $gateway_uri"

--- a/build-gateway.sh
+++ b/build-gateway.sh
@@ -14,17 +14,22 @@ fi
 # `docker build` on an Apple Silicon Mac produces an arm64 image that
 # crashloops on k8s with "exec format error" (see the 2026-08-05 whirlwind
 # staging incident, tatsuworks/whirlwind#56).
-# gateway_uri="gcr.io/tatsu-production/gateway:$VERSION"
-gateway_uri="6222o0k9.gra7.container-registry.ovh.net/tatsu/gateway:$VERSION"
-docker build --platform linux/amd64 -t "$gateway_uri" -f Dockerfile.gateway .
+readonly BUILD_PLATFORM="linux/amd64"
 
 # Refuse to push an image with the wrong architecture.
-arch="$(docker image inspect "$gateway_uri" --format '{{.Architecture}}')"
-if [[ "$arch" != "amd64" ]]; then
-  echo "Built image architecture is '$arch', expected amd64 — not pushing." >&2
-  exit 1
-fi
+assert_amd64() {
+  local image="$1" arch
+  arch="$(docker image inspect "$image" --format '{{.Architecture}}')"
+  if [[ "$arch" != "amd64" ]]; then
+    echo "Built image architecture for $image is '$arch', expected amd64 — not pushing." >&2
+    exit 1
+  fi
+}
 
+# gateway_uri="gcr.io/tatsu-production/gateway:$VERSION"
+gateway_uri="6222o0k9.gra7.container-registry.ovh.net/tatsu/gateway:$VERSION"
+docker build --platform "$BUILD_PLATFORM" -t "$gateway_uri" -f Dockerfile.gateway .
+assert_amd64 "$gateway_uri"
 docker push "$gateway_uri"
 
 echo "New gateway image URI: $gateway_uri"

--- a/build.sh
+++ b/build.sh
@@ -10,15 +10,33 @@ if [[ $VERSION == *-dirty ]]; then
   VERSION+="-$(head -c 5 < /dev/urandom | base32)"
 fi
 
+# Cluster nodes are amd64, so always build for linux/amd64 — a plain
+# `docker build` on an Apple Silicon Mac produces an arm64 image that
+# crashloops on k8s with "exec format error" (see the 2026-08-05 whirlwind
+# staging incident, tatsuworks/whirlwind#56).
+readonly BUILD_PLATFORM="linux/amd64"
+
+# Refuse to push an image with the wrong architecture.
+assert_amd64() {
+  local image="$1" arch
+  arch="$(docker image inspect "$image" --format '{{.Architecture}}')"
+  if [[ "$arch" != "amd64" ]]; then
+    echo "Built image architecture for $image is '$arch', expected amd64 — not pushing." >&2
+    exit 1
+  fi
+}
+
 # gateway_uri="gcr.io/tatsu-production/gateway:$VERSION"
 gateway_uri="6222o0k9.gra7.container-registry.ovh.net/tatsu/gateway:$VERSION-release"
-docker build -t "$gateway_uri" -f Dockerfile.gateway .
+docker build --platform "$BUILD_PLATFORM" -t "$gateway_uri" -f Dockerfile.gateway .
+assert_amd64 "$gateway_uri"
 docker push "$gateway_uri"
 
 # state_uri="gcr.io/tatsu-production/state:$VERSION"
 state_uri="6222o0k9.gra7.container-registry.ovh.net/tatsu/state:$VERSION-release"
 
-docker build -t "$state_uri" -f Dockerfile.state .
+docker build --platform "$BUILD_PLATFORM" -t "$state_uri" -f Dockerfile.state .
+assert_amd64 "$state_uri"
 docker push "$state_uri"
 
 echo "New gateway image URI: $gateway_uri"


### PR DESCRIPTION
Same latent bug as the 2026-08-05 whirlwind staging incident (tatsuworks/whirlwind#56): `build.sh` and `build-gateway.sh` ran plain `docker build`, so building on an Apple Silicon Mac produces **arm64** gateway/state images that crashloop on the amd64 cluster nodes with `exec format error`. Atlas's `build.sh` already pins the platform; this brings gateway in line.

## Fix

- `--platform linux/amd64` on all three docker build invocations (gateway + state in `build.sh`, gateway in `build-gateway.sh`). On amd64 hosts this is a no-op (native default); on arm64 Macs it cross-builds via Rosetta/QEMU to the correct arch.
- Post-build guard before every push: inspect the built image's architecture and abort if it isn't amd64, so a mis-built image can never reach the registry.

Both scripts use the same `BUILD_PLATFORM` constant and `assert_amd64` helper, so the two siblings stay identical in that region.

The script's output contract is unchanged — the `-release` tag suffix and the two `New gateway/state image URI:` lines are exactly as before.

## Verification

`bash -n` clean on both scripts.

The `assert_amd64` guard itself was executed against real local images (function extracted from `build-gateway.sh` and run directly — no build, no push), covering all three paths:

| Input | Result |
| --- | --- |
| `whirlwind:v2.0.0-318-gcb1b2a5` (known amd64) | passes silently |
| `whirlwind:v2.0.0-317-g63715f7` (**the actual arm64 image that broke staging**) | aborts, exit 1, before any push |
| nonexistent image | aborts on `docker image inspect` failure — fails closed rather than falling through to the push |

So the guard demonstrably would have caught the incident that motivated this change. No gateway image build was run for this PR (nothing needed shipping); the `--platform` pin is the same one verified end-to-end in whirlwind#56, where the amd64 rebuild deployed cleanly to staging.

## Follow-up (not this PR)

`Dockerfile.gateway` / `Dockerfile.state` run `go build` *inside* the target-platform image, so on an arm64 Mac `--platform linux/amd64` emulates the whole `golang:1.25` toolchain under QEMU — correct output, but slow. There is no cgo anywhere in the repo, so these could cross-compile natively instead (`FROM --platform=$BUILDPLATFORM golang:1.25`, `ARG TARGETARCH`, `GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 go build`), which keeps the arch guard passing while building at native speed. Left out of scope here since it means changing the Dockerfiles rather than the build scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
